### PR TITLE
owr_local: add G_{BEGIN,END}_DECLS

### DIFF
--- a/local/owr_local.h
+++ b/local/owr_local.h
@@ -34,8 +34,12 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 typedef void (*OwrCaptureSourcesCallback) (GList *sources, gpointer user_data);
 
 void owr_get_capture_sources(OwrMediaType types, OwrCaptureSourcesCallback callback, gpointer user_data);
+
+G_END_DECLS
 
 #endif /* __OWR_LOCAL_H__ */


### PR DESCRIPTION
This is needed so the owr_local exported symbols are visible from C++ world.
