### PR TITLE
build: Make sure we have the scripts submodule

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,11 @@ SCRIPT_DIR="$REPO_ROOT/scripts/engine"
 
 export XML_CATALOG_FILES=~/.openwebrtc/etc/xml/catalog
 
+if [[ ! -d $SCRIPT_DIR ]]; then
+    git submodule init
+    git submodule update
+fi
+
 #
 # Check preconditions:
 # 1. Check if file releases are missing and download in that case.


### PR DESCRIPTION
This should avoid some confusion when forgetting the --recursive flag or using a desktop client.
