### PR TITLE
Makefile: Removed INSTALL, fixes #24

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,8 +12,7 @@ export DEBUG_CFLAGS
 openwebrtcdocdir = ${prefix}/share/doc/libopenwebrtc
 openwebrtcdoc_DATA = \
     COPYING \
-    ChangeLog \
-    INSTALL
+    ChangeLog
 
 EXTRA_DIST = $(openwebrtcdoc_DATA)
 


### PR DESCRIPTION
Install was being generated by autotools, and since the `foreign` flag was added it is no longer generated.
