### PR TITLE
Fix interop with Chrome for Android

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -636,7 +636,13 @@
                 return;
             }
 
-            var candidateInfo = SDP.parse("m=application 0 NONE\r\na=" + candidate.candidate + "\r\n");
+            /* handle candidate values in the form <candidate> and a=<candidate>
+             * to workaround https://code.google.com/p/webrtc/issues/detail?id=1142
+             */
+            var candidateAttribute = candidate.candidate;
+            if (candidateAttribute.substr(0, 2) != "a=")
+                candidateAttribute = "a=" + candidateAttribute;
+            var candidateInfo = SDP.parse("m=application 0 NONE\r\n" + candidateAttribute + "\r\n");
 
             if (!candidateInfo.mediaDescriptions[0]
                 || !candidateInfo.mediaDescriptions[0].ice


### PR DESCRIPTION
These two changes fix interop with Chrome for Android version 37.0.2062.117 on my nexus 5. b2e8536 is pretty obvious, it fixes an instance where an exception was thrown with "throw" instead of going through the required hoops needed to handle errors. d7d50d4 is a workaround for a bug in chrome for android, but it's innocent enough to go in IMO.
