### PR TITLE
Add test utilities

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-SUBDIRS = transport local owr bridge docs
+SUBDIRS = transport local owr bridge tests docs
 
 if OWR_DEBUG
 DEBUG_CFLAGS = "-g"

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,7 @@ owr/Makefile
 owr/openwebrtc-0.1.pc
 transport/Makefile
 local/Makefile
+tests/Makefile
 docs/Makefile
 docs/reference/Makefile
 docs/reference/owr/Makefile

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,47 @@
+AM_CPPFLAGS = \
+    -DPACKAGE_LOCALE_DIR=\""$(localedir)"\" \
+    -DPACKAGE_SRC_DIR=\""$(srcdir)"\" \
+    -DPACKAGE_DATA_DIR=\""$(pkgdatadir)"\" \
+    $(GLIB_CFLAGS) \
+    $(NICE_CFLAGS) \
+    $(GSTREAMER_CFLAGS) \
+    -I$(top_srcdir)/local \
+    -I$(top_srcdir)/transport \
+    -I$(top_srcdir)/owr
+
+AM_CFLAGS = \
+    -ansi \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -pedantic
+
+bin_PROGRAMS = \
+    test-self-view \
+    test-send-receive
+
+test_self_view_SOURCES = test_self_view.c
+
+test_self_view_CFLAGS = \
+    -I$(top_srcdir)/local \
+    -I$(top_srcdir)/owr
+
+test_self_view_LDADD = \
+    $(GSTREAMER_LIBS) \
+    $(GLIB_LIBS) \
+    $(top_builddir)/owr/libopenwebrtc.la
+
+test_send_receive_SOURCES = test_send_receive.c
+
+test_send_receive_CFLAGS = \
+    -I$(top_srcdir)/local \
+    -I$(top_srcdir)/transport \
+    -I$(top_srcdir)/owr
+
+test_send_receive_LDADD = \
+    $(GSTREAMER_LIBS) \
+    $(NICE_LIBS) \
+    $(GLIB_LIBS) \
+    $(top_builddir)/owr/libopenwebrtc.la
+
+-include $(top_srcdir)/git.mk

--- a/tests/test_self_view.c
+++ b/tests/test_self_view.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014, Ericsson AB. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE 1
+
+#include <string.h>
+
+#include "owr.h"
+#include "owr_local.h"
+#include "owr_media_source.h"
+#include "owr_media_renderer.h"
+#include "owr_audio_renderer.h"
+#include "owr_video_renderer.h"
+
+gboolean dump_pipeline(gpointer user_data)
+{
+    g_print("Dumping pipeline\n");
+    owr_dump_dot_file("test_self_view");
+    return FALSE;
+}
+
+void got_sources(GList *sources, gpointer user_data)
+{
+    OwrMediaSource *source = NULL;
+    static gboolean have_video = FALSE, have_audio = FALSE;
+    g_assert(sources);
+
+    g_print("Got sources!\n");
+
+    while(sources && (source = sources->data)) {
+        OwrMediaType media_type;
+        OwrSourceType source_type;
+
+        g_assert(OWR_IS_MEDIA_SOURCE(source));
+
+        g_object_get(source, "type", &source_type, "media-type", &media_type, NULL);
+
+        if (!have_video && media_type == OWR_MEDIA_TYPE_VIDEO && source_type == OWR_SOURCE_TYPE_CAPTURE) {
+            OwrVideoRenderer *renderer;
+
+            have_video = TRUE;
+
+            renderer = owr_video_renderer_new(NULL);
+            g_assert(renderer);
+
+            owr_media_renderer_set_source(OWR_MEDIA_RENDERER(renderer), source);
+        } else if (!have_audio && media_type == OWR_MEDIA_TYPE_AUDIO && source_type == OWR_SOURCE_TYPE_CAPTURE) {
+            OwrAudioRenderer *renderer;
+
+            have_audio = TRUE;
+
+            renderer = owr_audio_renderer_new();
+            g_assert(renderer);
+
+            owr_media_renderer_set_source(OWR_MEDIA_RENDERER(renderer), source);
+        }
+
+        if (have_video && have_audio)
+            break;
+
+        sources = sources->next;
+    }
+
+    g_timeout_add(5000, dump_pipeline, NULL);
+}
+
+int main() {
+    GMainContext *ctx = g_main_context_default();
+    GMainLoop *loop = g_main_loop_new(ctx, FALSE);
+
+    owr_init_with_main_context(ctx);
+
+    owr_get_capture_sources(OWR_MEDIA_TYPE_AUDIO|OWR_MEDIA_TYPE_VIDEO, got_sources, NULL);
+
+    g_main_loop_run(loop);
+
+    return 0;
+}

--- a/tests/test_send_receive.c
+++ b/tests/test_send_receive.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2014, Ericsson AB. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE 1
+#include <string.h>
+
+#include "owr.h"
+#include "owr_local.h"
+#include "owr_media_source.h"
+#include "owr_media_renderer.h"
+#include "owr_audio_renderer.h"
+#include "owr_video_renderer.h"
+#include "owr_payload.h"
+#include "owr_audio_payload.h"
+#include "owr_video_payload.h"
+#include "owr_session.h"
+#include "owr_media_session.h"
+#include "owr_transport_agent.h"
+
+OwrTransportAgent *recv_transport_agent = NULL;
+OwrMediaSession *recv_session_audio = NULL;
+OwrMediaSession *recv_session_video = NULL;
+OwrTransportAgent *send_transport_agent = NULL;
+OwrMediaSession *send_session_audio = NULL;
+OwrMediaSession *send_session_video = NULL;
+
+void got_remote_source(OwrMediaSession *session, OwrMediaSource *source, gpointer user_data)
+{
+    gchar *name = NULL;
+    OwrMediaType media_type;
+
+    g_assert(!user_data);
+
+    g_object_get(source, "media-type", &media_type, "name", &name, NULL);
+
+    g_print("Got remote source: %s\n", name);
+
+    if (media_type == OWR_MEDIA_TYPE_VIDEO) {
+        OwrVideoRenderer *renderer;
+
+        g_print("Creating video renderer\n");
+        renderer = owr_video_renderer_new(NULL);
+        g_assert(renderer);
+
+        g_print("Connecting source to video renderer\n");
+        owr_media_renderer_set_source(OWR_MEDIA_RENDERER(renderer), source);
+    } else if (media_type == OWR_MEDIA_TYPE_AUDIO) {
+        OwrAudioRenderer *renderer;
+
+        g_print("Creating audio renderer\n");
+        renderer = owr_audio_renderer_new();
+        g_assert(renderer);
+
+        g_print("Connecting source to audio renderer\n");
+        owr_media_renderer_set_source(OWR_MEDIA_RENDERER(renderer), source);
+    }
+
+    g_free(name);
+
+    owr_dump_dot_file("test_receive");
+}
+
+void got_candidate(OwrMediaSession *session_a, OwrCandidate *candidate, OwrMediaSession *session_b)
+{
+    owr_session_add_remote_candidate(OWR_SESSION(session_b), candidate);
+}
+
+gboolean dump_cb(gpointer *user_data) {
+    if (user_data)
+        return G_SOURCE_REMOVE;
+    g_print("Dumping pipeline!\n");
+    owr_dump_dot_file("test_send_receive_timeout");
+    return G_SOURCE_REMOVE;
+}
+
+void got_sources(GList *sources, gpointer user_data)
+{
+    OwrMediaSource *source = NULL;
+    static gboolean have_video = FALSE, have_audio = FALSE;
+
+    g_assert(sources);
+
+    while(sources && (source = sources->data)) {
+        OwrMediaType media_type;
+        OwrSourceType source_type;
+
+        g_assert(OWR_IS_MEDIA_SOURCE(source));
+
+        g_object_get(source, "type", &source_type, "media-type", &media_type, NULL);
+
+        if (!have_video && media_type == OWR_MEDIA_TYPE_VIDEO && source_type == OWR_SOURCE_TYPE_CAPTURE) {
+            OwrVideoRenderer *renderer;
+            OwrPayload *payload;
+
+            have_video = TRUE;
+
+            payload = owr_video_payload_new(OWR_CODEC_TYPE_VP8, 103, 90000, TRUE, FALSE);
+
+            owr_media_session_set_send_payload(send_session_video, payload);
+
+            owr_media_session_set_send_source(send_session_video, source);
+
+            owr_transport_agent_add_session(send_transport_agent, OWR_SESSION(send_session_video));
+
+            g_print("Displaying self-view\n");
+
+            renderer = owr_video_renderer_new(NULL);
+            g_assert(renderer);
+            owr_media_renderer_set_source(OWR_MEDIA_RENDERER(renderer), source);
+        } else if (!have_audio && media_type == OWR_MEDIA_TYPE_AUDIO && source_type == OWR_SOURCE_TYPE_CAPTURE) {
+            OwrPayload *payload;
+
+            have_audio = TRUE;
+
+            payload = owr_audio_payload_new(OWR_CODEC_TYPE_OPUS, 100, 48000, 1);
+
+            owr_media_session_set_send_payload(send_session_audio, payload);
+
+            owr_media_session_set_send_source(send_session_audio, source);
+
+            owr_transport_agent_add_session(send_transport_agent, OWR_SESSION(send_session_audio));
+        }
+
+        if (have_video && have_audio)
+            break;
+
+        sources = sources->next;
+    }
+
+    owr_dump_dot_file("test_send");
+}
+
+int main() {
+    GMainContext *ctx = g_main_context_default();
+    GMainLoop *loop = g_main_loop_new(ctx, FALSE);
+
+    /* PREPARE FOR RECEIVING */
+
+    OwrPayload *receive_payload;
+
+    owr_init_with_main_context(ctx);
+
+    recv_transport_agent = owr_transport_agent_new(FALSE);
+    g_assert(OWR_IS_TRANSPORT_AGENT(recv_transport_agent));
+
+    owr_transport_agent_set_local_port_range(recv_transport_agent, 5000, 5999);
+    owr_transport_agent_add_local_address(recv_transport_agent, "127.0.0.1");
+
+    // SEND
+    send_transport_agent = owr_transport_agent_new(TRUE);
+    g_assert(OWR_IS_TRANSPORT_AGENT(send_transport_agent));
+
+    owr_transport_agent_set_local_port_range(send_transport_agent, 5000, 5999);
+    owr_transport_agent_add_local_address(send_transport_agent, "127.0.0.1");
+
+    recv_session_audio = owr_media_session_new(FALSE);
+    recv_session_video = owr_media_session_new(FALSE);
+    send_session_audio = owr_media_session_new(TRUE);
+    send_session_video = owr_media_session_new(TRUE);
+
+    g_signal_connect(recv_session_audio, "on-new-candidate", G_CALLBACK(got_candidate), send_session_audio);
+    g_signal_connect(recv_session_video, "on-new-candidate", G_CALLBACK(got_candidate), send_session_video);
+    g_signal_connect(send_session_audio, "on-new-candidate", G_CALLBACK(got_candidate), recv_session_audio);
+    g_signal_connect(send_session_video, "on-new-candidate", G_CALLBACK(got_candidate), recv_session_video);
+
+    // VIDEO
+    g_signal_connect(recv_session_video, "on-incoming-source", G_CALLBACK(got_remote_source), NULL);
+
+    receive_payload = owr_video_payload_new(OWR_CODEC_TYPE_VP8, 103, 90000, TRUE, FALSE);
+
+    owr_media_session_add_receive_payload(recv_session_video, receive_payload);
+
+    owr_transport_agent_add_session(recv_transport_agent, OWR_SESSION(recv_session_video));
+
+
+    // AUDIO
+    g_signal_connect(recv_session_audio, "on-incoming-source", G_CALLBACK(got_remote_source), NULL);
+
+    receive_payload = owr_audio_payload_new(OWR_CODEC_TYPE_OPUS, 100, 48000, 1);
+
+    owr_media_session_add_receive_payload(recv_session_audio, receive_payload);
+
+    owr_transport_agent_add_session(recv_transport_agent, OWR_SESSION(recv_session_audio));
+
+
+    /* PREPARE FOR SENDING */
+
+    owr_get_capture_sources(OWR_MEDIA_TYPE_AUDIO|OWR_MEDIA_TYPE_VIDEO, got_sources, NULL);
+
+
+    g_timeout_add_seconds(10, (GSourceFunc)dump_cb, NULL);
+
+    g_main_loop_run(loop);
+
+    return 0;
+}


### PR DESCRIPTION
Run ./out/<platform>/bin/test-self-view after building to run a simple
audio/video capture and output test.

Run ./out/<platform>/bin/test-send-receive after building to run a test
with one sender and one receiver in the same application.
