### PR TITLE
OwrMediaRenderer: fix refcount bug in owr_media_renderer_set_source

### DIFF
--- a/local/owr_media_renderer.c
+++ b/local/owr_media_renderer.c
@@ -246,7 +246,7 @@ gboolean owr_media_renderer_set_source(OwrMediaRenderer *renderer, OwrMediaSourc
 
     gst_element_post_message(_owr_get_pipeline(), gst_message_new_latency(GST_OBJECT(_owr_get_pipeline())));
 
-    priv->source = source;
+    priv->source = g_object_ref(source);
 
 done:
     priv->srcpad = srcpad;


### PR DESCRIPTION
Fix obvious refcount issue. Makes tests/test-send-receive from @superdump work.
