### PR TITLE
local: Remove capsfilter workaround after the audio source

### DIFF
--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -415,21 +415,6 @@ static GstElement *owr_local_media_source_request_source(OwrMediaSource *media_s
                 goto done;
             }
 
-#if defined(__APPLE__) && !TARGET_IPHONE_SIMULATOR
-            /* workaround for osxaudiosrc bug
-             * https://bugzilla.gnome.org/show_bug.cgi?id=711764 */
-            CREATE_ELEMENT(capsfilter, "capsfilter", "audio-source-capsfilter");
-            source_caps = gst_caps_copy(caps);
-            source_structure = gst_caps_get_structure(source_caps, 0);
-            gst_structure_set(source_structure,
-                "format", G_TYPE_STRING, "S32LE",
-                "rate", G_TYPE_INT, 44100, NULL);
-            gst_structure_remove_field(source_structure, "channels");
-            g_object_set(capsfilter, "caps", source_caps, NULL);
-            gst_caps_unref(source_caps);
-            gst_bin_add(GST_BIN(source_pipeline), capsfilter);
-#endif
-
             break;
             }
         case OWR_MEDIA_TYPE_VIDEO:


### PR DESCRIPTION
This should be unneeded now that the bug in osxaudiosrc is fixed.

See https://bugzilla.gnome.org/show_bug.cgi?id=711764
