### PR TITLE
transport: Use full ownership transfer for set_send_payload() and add_re...

### DIFF
--- a/tests/test_send_receive.c
+++ b/tests/test_send_receive.c
@@ -122,7 +122,6 @@ static void got_sources(GList *sources, gpointer user_data)
             payload = owr_video_payload_new(OWR_CODEC_TYPE_VP8, 103, 90000, TRUE, FALSE);
             g_object_set(payload, "width", 1280, "height", 720, "framerate", 30.0, NULL);
             owr_media_session_set_send_payload(send_session_video, payload);
-            g_object_unref(payload);
 
             owr_media_session_set_send_source(send_session_video, source);
 
@@ -143,7 +142,6 @@ static void got_sources(GList *sources, gpointer user_data)
 
             payload = owr_audio_payload_new(OWR_CODEC_TYPE_OPUS, 100, 48000, 1);
             owr_media_session_set_send_payload(send_session_audio, payload);
-            g_object_unref(payload);
 
             owr_media_session_set_send_source(send_session_audio, source);
 
@@ -214,7 +212,6 @@ int main() {
 
     receive_payload = owr_video_payload_new(OWR_CODEC_TYPE_VP8, 103, 90000, TRUE, FALSE);
     owr_media_session_add_receive_payload(recv_session_video, receive_payload);
-    g_object_unref(receive_payload);
 
     owr_transport_agent_add_session(recv_transport_agent, OWR_SESSION(recv_session_video));
 
@@ -224,7 +221,6 @@ int main() {
 
     receive_payload = owr_audio_payload_new(OWR_CODEC_TYPE_OPUS, 100, 48000, 1);
     owr_media_session_add_receive_payload(recv_session_audio, receive_payload);
-    g_object_unref(receive_payload);
 
     owr_transport_agent_add_session(recv_transport_agent, OWR_SESSION(recv_session_audio));
 

--- a/transport/owr_media_session.c
+++ b/transport/owr_media_session.c
@@ -315,7 +315,7 @@ OwrMediaSession * owr_media_session_new(gboolean dtls_client_mode)
 /**
  * owr_media_session_add_receive_payload:
  * @media_session: the media session on which to add the receive payload.
- * @payload: (transfer none): the receive payload to add
+ * @payload: (transfer full): the receive payload to add
  *
  * The function adds support for receiving the given payload type.
  */
@@ -331,15 +331,13 @@ void owr_media_session_add_receive_payload(OwrMediaSession *media_session, OwrPa
     g_hash_table_insert(args, "payload", payload);
 
     g_object_ref(media_session);
-    g_object_ref(payload);
     _owr_schedule_with_hash_table((GSourceFunc)add_receive_payload, args);
 }
-
 
 /**
  * owr_media_session_set_send_payload:
  * @media_session: The media session on which set the send payload.
- * @payload: (transfer none) (allow-none): the send payload to set
+ * @payload: (transfer full) (allow-none): the send payload to set
  *
  * Sets what payload that will be sent.
  */
@@ -354,12 +352,9 @@ void owr_media_session_set_send_payload(OwrMediaSession *media_session, OwrPaylo
     g_hash_table_insert(args, "media_session", media_session);
     g_hash_table_insert(args, "payload", payload);
     g_object_ref(media_session);
-    if (payload)
-        g_object_ref(payload);
 
     _owr_schedule_with_hash_table((GSourceFunc)set_send_payload, args);
 }
-
 
 /**
  * owr_media_session_set_send_source:
@@ -384,7 +379,6 @@ void owr_media_session_set_send_source(OwrMediaSession *media_session, OwrMediaS
 
     _owr_schedule_with_hash_table((GSourceFunc)set_send_source, args);
 }
-
 
 
 /* Internal functions */


### PR DESCRIPTION
...ceive_payload()

These are generally created by the application and would need to be unreffed
immediately after the function call like in the test-send-receive example.