### PR TITLE
Enable debug builds of 'local'

### DIFF
--- a/local/Makefile.am
+++ b/local/Makefile.am
@@ -12,7 +12,8 @@ AM_CPPFLAGS = \
 AM_CFLAGS = \
     -Wall \
     -Wextra \
-    -Werror
+    -Werror \
+    $(DEBUG_CFLAGS)
 
 noinst_LTLIBRARIES = libopenwebrtc_local.la
 


### PR DESCRIPTION
Any reason we're not using $(DEBUG_CFLAGS) in local?