### PR TITLE
Setting sdpMid to '""' instead of 'null' to be Chrome compatible.

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -986,7 +986,7 @@
 
             var candidate = new RTCIceCandidate({
                 "candidate": candidateAttribute,
-                "sdpMid": null,
+                "sdpMid": "",
                 "sdpMLineIndex": mdescIndex
             });
             _this.dispatchEvent({ "type": "icecandidate", "candidate": candidate,


### PR DESCRIPTION
Intended to fix issue #163.