### PR TITLE
owr: Use a pointer-sized integer for the require symbols hack

### DIFF
--- a/owr/owr_utils.h
+++ b/owr/owr_utils.h
@@ -39,7 +39,7 @@ G_BEGIN_DECLS
 
 #define OWR_UNUSED(x) (void)x
 
-int _owr_require_symbols(void);
+void *_owr_require_symbols(void);
 OwrCodecType _owr_caps_to_codec_type(GstCaps *caps);
 void _owr_utils_call_closure_with_list(GClosure *callback, GList *list);
 GClosure *_owr_utils_list_closure_merger_new(GClosure *final_callback, GDestroyNotify list_item_destroy);

--- a/owr/symbols_to_source.py
+++ b/owr/symbols_to_source.py
@@ -33,9 +33,9 @@ def symbols_to_source(infile_name, outfile_name, platform):
                 symbols.append(split[0].strip())
         outfile.write("#include <stdlib.h>\n")
         outfile.writelines(["extern void *%s;\n" % symbol for symbol in symbols])
-        outfile.write("\nint _%s(void)\n{\n    " % outfile_name.split(".")[0])
-        outfile.write("int ret = 0;\n    ")
-        lines = ["ret |= ((int) %s)" % symbol for symbol in symbols]
+        outfile.write("\nvoid *_%s(void)\n{\n    " % outfile_name.split(".")[0])
+        outfile.write("void *ret = 0;\n    ")
+        lines = ["ret |= %s" % symbol for symbol in symbols]
         outfile.writelines(";\n    ".join(lines))
         outfile.write(";\n    ")
         outfile.write("return ret;\n}\n\n")


### PR DESCRIPTION
Otherwise we will get warnings about casting pointers to integers of a smaller size.