### PR TITLE
Fixed so that the gUM Promise can be rejected.

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -142,8 +142,15 @@
                 bridge.removeObjectRef(client);
                 resolve(new MediaStream(trackList));
             };
-
-            bridge.requestSources(options, bridge.createObjectRef(client, "gotSources"));
+            client.noSources = function (reason) {
+                var message = "AbortError";
+                if (reason == "rejected") 
+                    message = "PermissionDeniedError";
+                else if (reason == "notavailable")
+                    message = "SourceUnavailableError";
+                reject(new MediaStreamError({"name": message}));
+            }
+            bridge.requestSources(options, bridge.createObjectRef(client, "gotSources", "noSources"));
         });
     }
 


### PR DESCRIPTION
Two reasons implemented now: no sources found and user does not approve usage. Not able to fulfill constraints will be added later.

Reports the right MediaStreamError's back to the application (which will catch them using .catch on the gUM promise), namely the names "SourceUnavailableError" and "PermissionDeniedError". Default error message name set to "AbortError".
