### PR TITLE
owr: Attach bus watch to the main context directly instead of modifying ...

### DIFF
--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -398,6 +398,7 @@ static GstElement *owr_local_media_source_request_source(OwrMediaSource *media_s
         gchar *bin_name;
         GstCaps *source_caps;
         GstBus *bus;
+        GSource *bus_source;
 
         g_object_get(media_source, "media-type", &media_type, "type", &source_type, NULL);
 
@@ -423,10 +424,10 @@ static GstElement *owr_local_media_source_request_source(OwrMediaSource *media_s
 #endif
 
         bus = gst_pipeline_get_bus(GST_PIPELINE(source_pipeline));
-        g_main_context_push_thread_default(_owr_get_main_context());
-        gst_bus_add_watch(bus, (GstBusFunc)bus_call, source_pipeline);
-        g_main_context_pop_thread_default(_owr_get_main_context());
-        gst_object_unref(bus);
+        bus_source = gst_bus_create_watch(bus);
+        g_source_set_callback(bus_source, (GSourceFunc) bus_call, source_pipeline, NULL);
+        g_source_attach(bus_source, _owr_get_main_context());
+        g_source_unref(bus_source);
 
         GST_DEBUG_OBJECT(local_source, "media_type: %d, type: %d", media_type, source_type);
 

--- a/local/owr_media_renderer.c
+++ b/local/owr_media_renderer.c
@@ -191,6 +191,7 @@ static void owr_media_renderer_init(OwrMediaRenderer *renderer)
 {
     OwrMediaRendererPrivate *priv;
     GstBus *bus;
+    GSource *bus_source;
     gchar *bin_name;
 
     renderer->priv = priv = OWR_MEDIA_RENDERER_GET_PRIVATE(renderer);
@@ -211,10 +212,10 @@ static void owr_media_renderer_init(OwrMediaRenderer *renderer)
     priv->src = NULL;
 
     bus = gst_pipeline_get_bus(GST_PIPELINE(priv->pipeline));
-    g_main_context_push_thread_default(_owr_get_main_context());
-    gst_bus_add_watch(bus, (GstBusFunc)bus_call, priv->pipeline);
-    g_main_context_pop_thread_default(_owr_get_main_context());
-    gst_object_unref(bus);
+    bus_source = gst_bus_create_watch(bus);
+    g_source_set_callback(bus_source, (GSourceFunc) bus_call, priv->pipeline, NULL);
+    g_source_attach(bus_source, _owr_get_main_context());
+    g_source_unref(bus_source);
 
     g_mutex_init(&priv->media_renderer_lock);
 }

--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -349,6 +349,7 @@ static void owr_transport_agent_init(OwrTransportAgent *transport_agent)
 {
     OwrTransportAgentPrivate *priv;
     GstBus *bus;
+    GSource *bus_source;
     gchar *pipeline_name;
 
     transport_agent->priv = priv = OWR_TRANSPORT_AGENT_GET_PRIVATE(transport_agent);
@@ -379,10 +380,10 @@ static void owr_transport_agent_init(OwrTransportAgent *transport_agent)
 #endif
 
     bus = gst_pipeline_get_bus(GST_PIPELINE(priv->pipeline));
-    g_main_context_push_thread_default(_owr_get_main_context());
-    gst_bus_add_watch(bus, (GstBusFunc)bus_call, priv->pipeline);
-    g_main_context_pop_thread_default(_owr_get_main_context());
-    gst_object_unref(bus);
+    bus_source = gst_bus_create_watch(bus);
+    g_source_set_callback(bus_source, (GSourceFunc) bus_call, priv->pipeline, NULL);
+    g_source_attach(bus_source, _owr_get_main_context());
+    g_source_unref(bus_source);
 
     priv->transport_bin_name = g_strdup_printf("transport_bin_%u", priv->agent_id);
     priv->transport_bin = gst_bin_new(priv->transport_bin_name);


### PR DESCRIPTION
...the thread default one temporarily

Modifying the thread default main context requires acquiring the main context,
which is not possible if a main loop is iterating over it from another thread.