### PR TITLE
bindings/java: Fix typo in env variable

### DIFF
--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -40,7 +40,7 @@ OWR_GIR = Owr-0.1.gir
 endif
 
 owr_jni.c: $(OWR_GIR) $(top_srcdir)/bindings/java/
-	PYTHONDONTWRITEBYTECODE=x $(top_srcdir)/bindings/java/gen_jni.py \
+	PYTHONDONTWRITEBYTECODE=1 $(top_srcdir)/bindings/java/gen_jni.py \
 	--gir=$< \
 	--c-out=$(top_builddir)/bindings/java/owr_jni.c \
 	--j-out=$(top_builddir)/bindings/java/owr


### PR DESCRIPTION
The 'x' in the documentation doesn't literally mean 'x'. It means 0 or 1.