### PR TITLE
build: new configure option to disable the bridge compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,10 @@
 ## Process this file with automake to produce Makefile.in
 
-SUBDIRS = transport local owr bridge tests docs bindings
+SUBDIRS = transport local owr tests docs bindings
+
+if OWR_BRIDGE
+SUBDIRS += bridge
+endif
 
 if OWR_DEBUG
 DEBUG_CFLAGS = "-g"

--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -13,16 +13,22 @@ AM_CFLAGS = \
 	-Wextra \
 	$(DEBUG_CFLAGS)
 
-lib_LTLIBRARIES = libopenwebrtc_jni.la libopenwebrtc_bridge_jni.la
+lib_LTLIBRARIES = libopenwebrtc_jni.la
+
+if OWR_BRIDGE
+lib_LTLIBRARIES += libopenwebrtc_bridge_jni.la
+endif
 
 libopenwebrtc_jni_la_SOURCES = owr_jni.c
 libopenwebrtc_jni_la_LIBADD = \
 	$(top_builddir)/owr/libopenwebrtc.la
 
+if OWR_BRIDGE
 libopenwebrtc_bridge_jni_la_SOURCES = owr_bridge_jni.c
 libopenwebrtc_bridge_jni_la_LIBADD = \
 	$(top_builddir)/bindings/java/libopenwebrtc_jni.la \
 	$(top_builddir)/bridge/libopenwebrtc_bridge.la
+endif
 
 BUILT_SOURCES = owr_jni.c
 noinst_DATA = \
@@ -66,7 +72,7 @@ install-data-local: install-exec
 	cp -r javadoc/* '$(DESTDIR)/$(javadocdir)'
 	mkdir -p '$(DESTDIR)/$(jardir)'
 	rm -rf jar-build && mkdir -p jar-build/lib/armeabi
-	for eachlib in '$(DESTDIR)/$(libdir)'/libopenwebrtc{,_bridge}{,_jni}.so; do \
+	for eachlib in '$(DESTDIR)/$(libdir)'/libopenwebrtc{,_jni}.so; do \
 		cp -L $$eachlib jar-build/lib/armeabi; \
 	done
 	$(JAR) cvf '$(DESTDIR)/$(jardir)/openwebrtc.jar' \
@@ -77,10 +83,15 @@ install-data-local: install-exec
 	$(JAR) cvf '$(DESTDIR)/$(jardir)/openwebrtc-source.jar' \
 		-C owr com/ericsson/research/owr \
 		-C owr com/ericsson/research
+if OWR_BRIDGE
+	for eachlib in '$(DESTDIR)/$(libdir)'/libopenwebrtc_bridge{,_jni}.so; do \
+		cp -L $$eachlib jar-build/lib/armeabi; \
+	done
 	$(JAR) cvf '$(DESTDIR)/$(jardir)/openwebrtc_bridge.jar' \
 		-C gen/bridge com/ericsson/research/owr \
 		-C jar-build lib/armeabi/libopenwebrtc_bridge.so \
 		-C jar-build lib/armeabi/libopenwebrtc_bridge_jni.so
+endif
 	rm -rf jar-build
 
 -include $(top_srcdir)/git.mk

--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,28 @@ PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 >= $GST_REQUIRED gstreamer-rtp-1.0 >
 PKG_CHECK_MODULES(NICE, [nice >= 0.1.7.1])
 PKG_CHECK_MODULES(GSTREAMER_SCTP, [gstreamer-sctp-1.0])
 PKG_CHECK_MODULES(ORC, [orc-0.4])
-PKG_CHECK_MODULES(SEED, [seed])
 PKG_CHECK_MODULES(JSON_GLIB, [json-glib-1.0])
 PKG_CHECK_MODULES(LIBSOUP, [libsoup-2.4])
+
+dnl build bridge or not
+AC_MSG_CHECKING([whether to build bridge or not])
+AC_ARG_ENABLE(bridge,
+AC_HELP_STRING(
+  [--enable-bridge],
+  [Enable bridge @<:@default=yes@:>@]),
+[case "${enableval}" in
+  yes) enable_bridge=yes ;;
+  no)  enable_bridge=no ;;
+  *) AC_MSG_ERROR(bad value ${enableval} for --enable-bridge) ;;
+esac],[enable_bridge=yes])
+AC_MSG_RESULT([$enable_bridge])
+if test "x$enable_bridge" = xyes; then
+  AC_DEFINE(OWR_BRIDGE, 1,
+  [Define if building bridge])
+  PKG_CHECK_MODULES(SEED, [seed])
+fi
+AM_CONDITIONAL(OWR_BRIDGE, test x$enable_bridge = xyes)
+
 
 # check for gobject-introspection
 m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [


### PR DESCRIPTION
The bridge library requires Seed, which pulls a lot of dependencies
for the build of OpenWebRTC. This library not being essential for the
C/GObject Owr API can thus be disabled during ./configure.

The new --enable-bridge defaults to 'yes'.
See also issue #159