### PR TITLE
./Makefile.am: build bindings last

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,13 @@
 ## Process this file with automake to produce Makefile.in
 
-SUBDIRS = transport local owr tests docs bindings
+SUBDIRS = transport local owr tests docs
 
 if OWR_BRIDGE
 SUBDIRS += bridge
 endif
+
+# bindings need to be generated last
+SUBDIRS += bindings
 
 if OWR_DEBUG
 DEBUG_CFLAGS = "-g"


### PR DESCRIPTION
Without this change the android build failed with the following error:
```No rule to make target `../../bridge/libopenwebrtc_bridge.la', needed by `libopenwebrtc_bridge_jni.la'.  Stop. ```