### PR TITLE
sdp.js: discard TCP candidates without explicit tcptype or port set to 0 or 9

### DIFF
--- a/bridge/client/sdp.js
+++ b/bridge/client/sdp.js
@@ -310,6 +310,8 @@ if (typeof(SDP) == "undefined")
                         if (candidate.port == 0 || candidate.port == 9) {
                             candidate.tcpType = "active";
                             candidate.port = 9;
+                        } else {
+                            return;
                         }
                     }
                     mediaDescription.ice.candidates.push(candidate);


### PR DESCRIPTION
Without this change an invalid tcp candidate might be treated as a valid UDP candidate in peerhandler.js