### PR TITLE
sdp.js: treat sessionId as a string

### DIFF
--- a/bridge/client/sdp.js
+++ b/bridge/client/sdp.js
@@ -158,7 +158,7 @@ if (typeof(SDP) == "undefined")
         if (originator) {
             sdpObj.originator = {
                 "username": originator[1],
-                "sessionId": parseInt(originator[2]),
+                "sessionId": originator[2],
                 "sessionVersion": parseInt(originator[3]),
                 "netType": "IN",
                 "addressType": originator[4],
@@ -365,7 +365,7 @@ if (typeof(SDP) == "undefined")
         });
         addDefaults(sdpObj.originator, {
             "username": "-",
-            "sessionId": Math.floor((Math.random() + +new Date()) * 1e6),
+            "sessionId": "" + Math.floor((Math.random() + +new Date()) * 1e6),
             "sessionVersion": 1,
             "netType": "IN",
             "addressType": "IP4",


### PR DESCRIPTION
sessionIds can't be accurately represented as a javascript number, so use a string instead.

I'll look around and see if this breaks any example applications, but I at least couldn't find any other use inside owr itself.