### PR TITLE
local: Drop libv4l2 dependency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -108,8 +108,6 @@ build(){
             local seed_platform_libs="-ljavascriptcoregtk-3.0 -licui18n -licuuc -licudata"
             export PULSE_CFLAGS="$(/usr/bin/pkg-config --cflags libpulse-mainloop-glib) $(/usr/bin/pkg-config --cflags libpulse) "
             export PULSE_LIBS="$(/usr/bin/pkg-config --libs libpulse-mainloop-glib) $(/usr/bin/pkg-config --libs libpulse) "
-            export V4L2_CFLAGS="$(/usr/bin/pkg-config --cflags libv4l2) "
-            export V4L2_LIBS="$(/usr/bin/pkg-config --libs libv4l2) "
             export PLATFORM_GLIB_LIBS="-lpthread -lffi -lrt -ldl -lresolv"
             export PLATFORM_GSTREAMER_LIBS="-lgstvideoconvert -lgstpulse -lgstvideo4linux2 -lX11 -lXv -lgstallocators-1.0 -lGLU -lGL"
             export PLATFORM_CXX_LIBS="-lstdc++"

--- a/configure.ac
+++ b/configure.ac
@@ -110,9 +110,8 @@ case "$host_os" in
     ;;
   linux*)
     PKG_CHECK_MODULES(PULSE, [libpulse libpulse-mainloop-glib])
-    PKG_CHECK_MODULES(V4L2, [libv4l2])
-    OWR_DEVICE_LIST_EXT_CFLAGS="\$(PULSE_CFLAGS) \$(V4L2_CFLAGS)"
-    OWR_DEVICE_LIST_EXT_LIBS="\$(PULSE_LIBS) \$(V4L2_LIBS)"
+    OWR_DEVICE_LIST_EXT_CFLAGS="\$(PULSE_CFLAGS)"
+    OWR_DEVICE_LIST_EXT_LIBS="\$(PULSE_LIBS)"
     ;;
 esac
 AC_SUBST(OWR_DEVICE_LIST_EXT_LIBS)

--- a/local/owr_device_list.c
+++ b/local/owr_device_list.c
@@ -55,7 +55,8 @@
 
 #elif defined(__linux__)
 #include <fcntl.h>
-#include <libv4l2.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
 #include <linux/videodev2.h>
 
 #endif /* defined(__linux__) */
@@ -299,7 +300,7 @@ static gchar *get_v4l2_device_name(gchar *filename)
         return NULL;
     }
 
-    if (v4l2_ioctl(fd, VIDIOC_QUERYCAP, &vcap) < 0) {
+    if (ioctl(fd, VIDIOC_QUERYCAP, &vcap) < 0) {
         g_warning("v4l: failed to query %s", filename);
 
         device_name = g_strdup(filename);


### PR DESCRIPTION
We only needed it for v4l2_ioctl(), and that can just be replaced by
ioctl().