### PR TITLE
replace gst_object_default_deep_notify with a less verbose _owr_deep_notify that uses log level info

### DIFF
--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -420,7 +420,7 @@ static GstElement *owr_local_media_source_request_source(OwrMediaSource *media_s
         bin_name = NULL;
 
 #ifdef OWR_DEBUG
-        g_signal_connect(source_pipeline, "deep-notify", G_CALLBACK(gst_object_default_deep_notify), NULL);
+        g_signal_connect(source_pipeline, "deep-notify", G_CALLBACK(_owr_deep_notify), NULL);
 #endif
 
         bus = gst_pipeline_get_bus(GST_PIPELINE(source_pipeline));

--- a/local/owr_media_renderer.c
+++ b/local/owr_media_renderer.c
@@ -205,7 +205,7 @@ static void owr_media_renderer_init(OwrMediaRenderer *renderer)
     g_free(bin_name);
 
 #ifdef OWR_DEBUG
-    g_signal_connect(priv->pipeline, "deep-notify", G_CALLBACK(gst_object_default_deep_notify), NULL);
+    g_signal_connect(priv->pipeline, "deep-notify", G_CALLBACK(_owr_deep_notify), NULL);
 #endif
 
     priv->sink = NULL;

--- a/owr/owr_utils.h
+++ b/owr/owr_utils.h
@@ -54,6 +54,9 @@ typedef gboolean (*OwrGstCapsForeachFunc) (GstCapsFeatures *features,
                                            gpointer         user_data);
 gboolean _owr_gst_caps_foreach(const GstCaps *caps, OwrGstCapsForeachFunc func, gpointer user_data);
 
+void _owr_deep_notify(GObject *object, GstObject *orig,
+    GParamSpec *pspec, gpointer user_data);
+
 G_END_DECLS
 
 #endif /* __GTK_DOC_IGNORE__ */

--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -376,7 +376,7 @@ static void owr_transport_agent_init(OwrTransportAgent *transport_agent)
     g_free(pipeline_name);
 
 #ifdef OWR_DEBUG
-    g_signal_connect(priv->pipeline, "deep-notify", G_CALLBACK(gst_object_default_deep_notify), NULL);
+    g_signal_connect(priv->pipeline, "deep-notify", G_CALLBACK(_owr_deep_notify), NULL);
 #endif
 
     bus = gst_pipeline_get_bus(GST_PIPELINE(priv->pipeline));


### PR DESCRIPTION
There was a bit too much g_print spam :no_mouth: 