### PR TITLE
sdp.js: removed maxMessageSize from sctpmap template and regex

### DIFF
--- a/bridge/client/sdp.js
+++ b/bridge/client/sdp.js
@@ -57,7 +57,7 @@ if (typeof(SDP) == "undefined")
             "( tcptype (active|passive|so))?.*$",
         "fingerprint": "^a=fingerprint:(sha-1|sha-256) ([A-Fa-f\\d\:]+).*$",
         "setup": "^a=setup:(actpass|active|passive).*$",
-        "sctpmap": "^a=sctpmap:${port} ([\\w\\-]+)( [\\d]{3,})?( [\\d]+)?.*$"
+        "sctpmap": "^a=sctpmap:${port} ([\\w\\-]+)( [\\d]+)?.*$"
     };
 
     var templates = {
@@ -112,7 +112,7 @@ if (typeof(SDP) == "undefined")
         "dtlsFingerprint": "a=fingerprint:${fingerprintHashFunction} ${fingerprint}\r\n",
         "dtlsSetup": "a=setup:${setup}\r\n",
 
-        "sctpmap": "a=sctpmap:${port} ${app}${[ ]maxMessageSize}${[ ]streams}\r\n"
+        "sctpmap": "a=sctpmap:${port} ${app}${[ ]streams}\r\n"
     };
 
     function match(data, pattern, flags, alt) {
@@ -343,9 +343,7 @@ if (typeof(SDP) == "undefined")
                 if (sctpmap) {
                     mediaDescription.sctp.app = sctpmap[1];
                     if (sctpmap[2])
-                        mediaDescription.sctp.maxMessageSize = parseInt(sctpmap[2]);
-                    if (sctpmap[3])
-                        mediaDescription.sctp.streams = parseInt(sctpmap[3]);
+                        mediaDescription.sctp.streams = parseInt(sctpmap[2]);
                 }
             }
 
@@ -497,7 +495,7 @@ if (typeof(SDP) == "undefined")
 
             var sctpInfo = {"sctpmapLine": "", "fmt": ""};
             if (mediaDescription.sctp) {
-                addDefaults(mediaDescription.sctp, {"maxMessageSize": null, "streams": null});
+                addDefaults(mediaDescription.sctp, {"streams": null});
                 sctpInfo.sctpmapLine = fillTemplate(templates.sctpmap, mediaDescription.sctp);
                 sctpInfo.fmt = mediaDescription.sctp.port;
             }

--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -597,7 +597,6 @@
                         "app": "webrtc-datachannel"
                     };
                     if (rmdesc.sctp) {
-                        lmdesc.sctp.maxMessageSize = rmdesc.sctp.maxMessageSize;
                         lmdesc.sctp.streams = rmdesc.sctp.streams;
                     }
                 } else {


### PR DESCRIPTION
The current implementation seems like a mix between https://tools.ietf.org/html/draft-ietf-mmusic-sctp-sdp-05#page-6 and https://tools.ietf.org/html/draft-ietf-mmusic-sctp-sdp-06#page-6

And since it seems like both Chrome and Firefox use this format at the moment, let's go with 05? :neutral_face: 