### PR TITLE
Fix to allow null and undefined if dictionary is expected

### DIFF
--- a/bridge/client/domutils.js
+++ b/bridge/client/domutils.js
@@ -181,6 +181,10 @@ function canConvert(value, expectedTypes) {
             if (!isNaN(asNumber) && asNumber != -Infinity && asNumber != Infinity)
                 return true;
         }
+        if (expectedType == "dictionary") { // object, undefined and null can be converted
+            if (type == "object" || type == "undefined" || type == "null")
+                return true;
+        }
         if (type == "object") {
             if (expectedType == "object")
                 return true;

--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -110,13 +110,13 @@
     bridge.importFunctions("createPeerHandler", "requestSources", "renderSources");
 
     function getUserMedia(options) {
-        checkArguments("getUserMedia", "object", 1, arguments);
+        checkArguments("getUserMedia", "dictionary", 1, arguments);
 
         return internalGetUserMedia(options);
     }
 
     function legacyGetUserMedia(options, successCallback, errorCallback) {
-        checkArguments("getUserMedia", "object, function, function", 3, arguments);
+        checkArguments("getUserMedia", "dictionary, function, function", 3, arguments);
 
         internalGetUserMedia(options).then(successCallback).catch(errorCallback);
     }
@@ -341,7 +341,7 @@
         };
         domObject.addReadOnlyAttributes(this, a);
 
-        checkArguments("RTCPeerConnection", "object", 1, arguments);
+        checkArguments("RTCPeerConnection", "dictionary", 1, arguments);
         checkConfigurationDictionary(configuration);
 
         if (!configuration.iceTransports)
@@ -447,13 +447,13 @@
 
         this.createOffer = function () {
             // backwards compatibility with callback based method
-            var callbackArgsError = getArgumentsError("function, function, object", 2, arguments);
+            var callbackArgsError = getArgumentsError("function, function, dictionary", 2, arguments);
             if (!callbackArgsError) {
                 internalCreateOffer(arguments[2]).then(arguments[0]).catch(arguments[1]);
                 return;
             }
 
-            var promiseArgsError = getArgumentsError("object", 0, arguments);
+            var promiseArgsError = getArgumentsError("dictionary", 0, arguments);
             if (!promiseArgsError)
                 return internalCreateOffer(arguments[0]);
 
@@ -537,13 +537,13 @@
 
         this.createAnswer = function () {
             // backwards compatibility with callback based method
-            var callbackArgsError = getArgumentsError("function, function, object", 2, arguments);
+            var callbackArgsError = getArgumentsError("function, function, dictionary", 2, arguments);
             if (!callbackArgsError) {
                 internalCreateAnswer(arguments[2]).then(arguments[0]).catch(arguments[1]);
                 return;
             }
 
-            var promiseArgsError = getArgumentsError("object", 0, arguments);
+            var promiseArgsError = getArgumentsError("dictionary", 0, arguments);
             if (!promiseArgsError)
                 return internalCreateAnswer(arguments[0]);
 
@@ -777,7 +777,7 @@
         };
 
         this.updateIce = function (configuration) {
-            checkArguments("updateIce", "object", 1, arguments);
+            checkArguments("updateIce", "dictionary", 1, arguments);
             checkConfigurationDictionary(configuration);
             checkClosedState("updateIce");
         };
@@ -982,7 +982,7 @@
 
             if (configuration.iceServers) {
                 configuration.iceServers.forEach(function (iceServer) {
-                    checkType("RTCConfiguration.iceServers", iceServer, "object");
+                    checkType("RTCConfiguration.iceServers", iceServer, "dictionary");
                     checkDictionary("RTCIceServer", iceServer, {
                         "urls": "Array | string",
                         "url": "string", // legacy support
@@ -1265,7 +1265,7 @@
     };
 
     function RTCSessionDescription(initDict) {
-        checkArguments("RTCSessionDescription", "object", 0, arguments);
+        checkArguments("RTCSessionDescription", "dictionary", 0, arguments);
         if (initDict) {
             checkDictionary("RTCSessionDescriptionInit", initDict, {
                 "type": "string",
@@ -1289,7 +1289,7 @@
     };
 
     function RTCIceCandidate(initDict) {
-        checkArguments("RTCIceCandidate", "object", 0, arguments);
+        checkArguments("RTCIceCandidate", "dictionary", 0, arguments);
         if (initDict) {
             checkDictionary("RTCIceCandidateInit", initDict, {
                 "candidate": "string",

--- a/local/owr_image_renderer.c
+++ b/local/owr_image_renderer.c
@@ -49,6 +49,12 @@
 #define DEFAULT_WIDTH 0
 #define DEFAULT_HEIGHT 0
 
+#if (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
+#define VIDEO_CONVERT "videoconvert"
+#else
+#define VIDEO_CONVERT "videoconvert"
+#endif
+
 #define DEFAULT_MAX_FRAMERATE 0.0
 
 #define LIMITED_WIDTH 640

--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -59,6 +59,7 @@
 #elif defined(__ANDROID__)
 #define AUDIO_SRC "openslessrc"
 #define VIDEO_SRC "androidvideosource"
+#define VIDEO_CONVERT "videoconvert"
 
 #elif defined(__linux__)
 #define AUDIO_SRC  "pulsesrc"

--- a/local/owr_video_renderer.c
+++ b/local/owr_video_renderer.c
@@ -50,7 +50,7 @@
 
 #define VIDEO_SINK "glimagesink"
 
-#if defined(__ANDROID__) || (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
+#if (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
 #define VIDEO_CONVERT "ercolorspace"
 #else
 #define VIDEO_CONVERT "videoconvert"

--- a/owr/owr.c
+++ b/owr/owr.c
@@ -107,7 +107,7 @@ GST_PLUGIN_STATIC_DECLARE(pulseaudio);
 GST_PLUGIN_STATIC_DECLARE(video4linux2);
 #endif
 
-#if defined(__ANDROID__) || (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
+#if (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
 GST_PLUGIN_STATIC_DECLARE(ercolorspace);
 #endif
 #endif
@@ -235,7 +235,7 @@ void owr_init()
     GST_PLUGIN_STATIC_REGISTER(pulseaudio);
     GST_PLUGIN_STATIC_REGISTER(video4linux2);
 #endif
-#if defined(__ANDROID__) || (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
+#if (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
     GST_PLUGIN_STATIC_REGISTER(ercolorspace);
 #endif
 

--- a/owr/owr.c
+++ b/owr/owr.c
@@ -107,10 +107,7 @@ GST_PLUGIN_STATIC_DECLARE(pulseaudio);
 GST_PLUGIN_STATIC_DECLARE(video4linux2);
 #endif
 
-#if (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
-GST_PLUGIN_STATIC_DECLARE(ercolorspace);
-#endif
-#endif
+#endif /* OWR_STATIC */
 
 #ifdef __ANDROID__
 static void g_print_android_handler(const gchar *message)
@@ -235,11 +232,8 @@ void owr_init()
     GST_PLUGIN_STATIC_REGISTER(pulseaudio);
     GST_PLUGIN_STATIC_REGISTER(video4linux2);
 #endif
-#if (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
-    GST_PLUGIN_STATIC_REGISTER(ercolorspace);
-#endif
 
-#endif
+#endif /* OWR_STATIC */
 
     owr_main_context_is_external = !!owr_main_context;
 


### PR DESCRIPTION
Relates to https://github.com/EricssonResearch/openwebrtc/issues/208. 
I note that there is some (for the Issue this PR is intended to address) garbage in the PR. Please review only the .js files
Also note that only if the expected type (or rather what the UA will translate to) is a dictionary, and only if the supplied argument is "undefined" it will be allowed without raising an error. It could be argued that any optional argument should be allowed to be undefined, and also that null should be allowed. But I think this is the right thing to do.