### PR TITLE
owr: Disable last-sample property on all sinks

### DIFF
--- a/local/owr_audio_renderer.c
+++ b/local/owr_audio_renderer.c
@@ -148,7 +148,8 @@ static GstElement *owr_audio_renderer_get_element(OwrMediaRenderer *renderer)
     g_assert(sink);
 
     g_object_set(sink, "buffer-time", SINK_BUFFER_TIME,
-        "latency-time", G_GINT64_CONSTANT(10000), NULL);
+        "latency-time", G_GINT64_CONSTANT(10000),
+        "enable-last-sample", FALSE, NULL);
 
     gst_bin_add_many(GST_BIN(renderer_bin), audioresample, audioconvert, capsfilter,
         volume, sink, NULL);

--- a/local/owr_image_renderer.c
+++ b/local/owr_image_renderer.c
@@ -215,7 +215,7 @@ static GstElement *owr_image_renderer_get_element(OwrMediaRenderer *renderer)
     g_assert(sink);
     priv->appsink = sink;
 
-    g_object_set(sink, "max-buffers", 1, "drop", TRUE, "qos", TRUE, NULL);
+    g_object_set(sink, "max-buffers", 1, "drop", TRUE, "qos", TRUE, "enable-last-sample", FALSE, NULL);
 
     gst_bin_add_many(GST_BIN(renderer_bin), sink, NULL);
 

--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -584,7 +584,7 @@ static GstElement *owr_local_media_source_request_source(OwrMediaSource *media_s
         CREATE_ELEMENT(queue, "queue", "source-tee-fakesink-queue");
 
         CREATE_ELEMENT(fakesink, "fakesink", "source-tee-fakesink");
-        g_object_set(fakesink, "async", FALSE, NULL);
+        g_object_set(fakesink, "async", FALSE, "enable-last-sample", FALSE, NULL);
 
         gst_bin_add_many(GST_BIN(source_pipeline), source, tee, queue, fakesink, NULL);
 

--- a/local/owr_video_renderer.c
+++ b/local/owr_video_renderer.c
@@ -266,6 +266,7 @@ static GstElement *owr_video_renderer_get_element(OwrMediaRenderer *renderer, gu
 
     sink = gst_element_factory_make(VIDEO_SINK, "video-renderer-sink");
     g_assert(sink);
+    g_object_set(sink, "enable-last-sample", FALSE, NULL);
     if (priv->tag) {
         GstElement *sink_element = GST_IS_BIN(sink) ?
             gst_bin_get_by_interface(GST_BIN(sink), GST_TYPE_VIDEO_OVERLAY) : sink;

--- a/transport/owr_remote_media_source.c
+++ b/transport/owr_remote_media_source.c
@@ -113,7 +113,7 @@ OwrMediaSource *_owr_remote_media_source_new(OwrMediaType media_type,
     tee = gst_element_factory_make("tee", "tee");
     _owr_media_source_set_source_tee(OWR_MEDIA_SOURCE(source), tee);
     fakesink = gst_element_factory_make("fakesink", "fakesink");
-    g_object_set(fakesink, "async", FALSE, NULL);
+    g_object_set(fakesink, "async", FALSE, "enable-last-sample", FALSE, NULL);
     queue = gst_element_factory_make("queue", "queue");
     g_free(bin_name);
 

--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -946,13 +946,13 @@ static GstElement *add_nice_element(OwrTransportAgent *transport_agent, guint st
     nice_element = gst_element_factory_make(is_sink ? "nicesink" : "nicesrc", element_name);
     g_free(element_name);
 
-    g_object_set(nice_element, "agent", transport_agent->priv->nice_agent, NULL);
-    g_object_set(nice_element, "stream", stream_id, NULL);
-    g_object_set(nice_element, "component", is_rtcp
+    g_object_set(nice_element, "agent", transport_agent->priv->nice_agent,
+        "stream", stream_id,
+        "component", is_rtcp
         ? NICE_COMPONENT_TYPE_RTCP : NICE_COMPONENT_TYPE_RTP, NULL);
 
     if (is_sink)
-        g_object_set(nice_element, "sync", FALSE, "async", FALSE, NULL);
+        g_object_set(nice_element, "sync", FALSE, "async", FALSE, "enable-last-sample", FALSE, NULL);
 
     added_ok = gst_bin_add(GST_BIN(bin), nice_element);
     g_warn_if_fail(added_ok);
@@ -2462,7 +2462,7 @@ static void sctpdec_pad_added(GstElement *sctpdec, GstPad *sctpdec_srcpad,
     g_free(name);
 
     g_object_set(G_OBJECT(data_sink), "emit-signals", FALSE, "drop", FALSE, "sync", FALSE, "async",
-        FALSE, NULL);
+        FALSE, "enable-last-sample", FALSE, NULL);
 
     g_assert(!data_channel_info->data_sink);
 


### PR DESCRIPTION
It is just wasting memory as we don't use it at all, and it also
causes elements with a limited number of buffers to potentially work
less efficient than they could as buffers are released later.

https://github.com/EricssonResearch/openwebrtc/issues/260#issuecomment-89353530