### PR TITLE
rtpjitterbuffer improvements

### DIFF
--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -86,6 +86,11 @@ static guint next_transport_agent_id = 1;
 G_DEFINE_TYPE(OwrTransportAgent, owr_transport_agent, G_TYPE_OBJECT)
 
 typedef struct {
+    OwrTransportAgent *transport_agent;
+    guint session_id;
+} AgentAndSessionIdPair;
+
+typedef struct {
     OwrDataChannelState state;
     GstElement *data_sink, *data_src;
     guint session_id;
@@ -132,12 +137,9 @@ struct _OwrTransportAgentPrivate {
     GHashTable *data_channels;
     GRWLock data_channels_rw_mutex;
     gboolean data_session_added, data_session_established;
+    
+    AgentAndSessionIdPair latest_jitterbuffer_pair;
 };
-
-typedef struct {
-    OwrTransportAgent *transport_agent;
-    guint session_id;
-} AgentAndSessionIdPair;
 
 #define GEN_HASH_KEY(seq, ssrc) (seq ^ ssrc)
 
@@ -169,6 +171,7 @@ static void on_rtpbin_pad_added(GstElement *rtpbin, GstPad *new_pad, OwrTranspor
 static void setup_video_receive_elements(GstPad *new_pad, guint32 session_id, OwrPayload *payload, OwrTransportAgent *transport_agent);
 static void setup_audio_receive_elements(GstPad *new_pad, guint32 session_id, OwrPayload *payload, OwrTransportAgent *transport_agent);
 static GstCaps * on_rtpbin_request_pt_map(GstElement *rtpbin, guint session_id, guint pt, OwrTransportAgent *agent);
+static GstCaps * on_rtpjitterbuffer_request_pt_map(GstElement *rtpjitterbuffer, guint pt, AgentAndSessionIdPair *data);
 static GstElement * on_rtpbin_request_aux_sender(GstElement *rtpbin, guint session_id, OwrTransportAgent *transport_agent);
 static GstElement * on_rtpbin_request_aux_receiver(GstElement *rtpbin, guint session_id, OwrTransportAgent *transport_agent);
 
@@ -413,6 +416,10 @@ static void owr_transport_agent_init(OwrTransportAgent *transport_agent)
     priv->data_session_established = FALSE;
 
     priv->send_bins = g_hash_table_new_full(NULL, NULL, NULL, g_free);
+    
+    // Set default invalid data for AgentAndSessionIdPair
+    priv->latest_jitterbuffer_pair.transport_agent = NULL;
+    priv->latest_jitterbuffer_pair.session_id = 0;
 }
 
 
@@ -2072,6 +2079,30 @@ static GstCaps * on_rtpbin_request_pt_map(GstElement *rtpbin, guint session_id, 
     return caps;
 }
 
+static GstCaps * on_rtpjitterbuffer_request_pt_map(GstElement *rtpjitterbuffer, guint pt, AgentAndSessionIdPair *data)
+{
+    OwrMediaSession *media_session = NULL;
+    OwrPayload *payload = NULL;
+    GstCaps *caps = NULL;
+
+    g_warning("rtpjitterbuffer request-pt");
+
+    g_return_val_if_fail(rtpjitterbuffer, NULL);
+    g_return_val_if_fail(data, NULL);
+    g_return_val_if_fail(OWR_IS_TRANSPORT_AGENT(data->transport_agent), NULL);
+
+    media_session = OWR_MEDIA_SESSION(get_session(data->transport_agent, data->session_id));
+    g_return_val_if_fail(OWR_IS_MEDIA_SESSION(media_session), NULL);
+
+    payload = _owr_media_session_get_receive_payload(media_session, pt);
+
+    caps = _owr_payload_create_rtp_caps(payload);
+    g_object_unref(payload);
+    g_object_unref(media_session);
+
+    return caps;
+}
+
 static GstElement * create_aux_bin(gchar *prefix, GstElement *rtx, guint session_id)
 {
     GstElement *bin;
@@ -2311,6 +2342,14 @@ static void on_new_jitterbuffer(G_GNUC_UNUSED GstElement *rtpbin, GstElement *ji
     
     // Enable lost packet propagation from jitter buffer
     g_object_set(jitterbuffer, "do-lost", TRUE, NULL);
+
+    // Set request-pt callback using AgentAndSessionIdPair for callback userdata
+    {
+      AgentAndSessionIdPair *pair = &transport_agent->priv->latest_jitterbuffer_pair;
+      pair->transport_agent = transport_agent;
+      pair->session_id = session_id;
+      g_signal_connect(jitterbuffer, "request-pt-map", G_CALLBACK(on_rtpjitterbuffer_request_pt_map), pair);
+    }
 
     if (_owr_media_session_want_receive_rtx(media_session))
         g_object_set(jitterbuffer, "do-retransmission", TRUE, NULL);

--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -2308,6 +2308,9 @@ static void on_new_jitterbuffer(G_GNUC_UNUSED GstElement *rtpbin, GstElement *ji
     g_return_if_fail(OWR_IS_TRANSPORT_AGENT(transport_agent));
     media_session = OWR_MEDIA_SESSION(get_session(transport_agent, session_id));
     g_return_if_fail(OWR_IS_MEDIA_SESSION(media_session));
+    
+    // Enable lost packet propagation from jitter buffer
+    g_object_set(jitterbuffer, "do-lost", TRUE, NULL);
 
     if (_owr_media_session_want_receive_rtx(media_session))
         g_object_set(jitterbuffer, "do-retransmission", TRUE, NULL);

--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -392,6 +392,7 @@ static void owr_transport_agent_init(OwrTransportAgent *transport_agent)
     priv->transport_bin = gst_bin_new(priv->transport_bin_name);
     priv->rtpbin = gst_element_factory_make("rtpbin", "rtpbin");
     g_object_set(priv->rtpbin, "do-lost", TRUE, NULL);
+    g_object_set(priv->rtpbin, "use-pipeline-clock", TRUE, NULL);
     g_signal_connect(priv->rtpbin, "pad-added", G_CALLBACK(on_rtpbin_pad_added), transport_agent);
     g_signal_connect(priv->rtpbin, "request-pt-map", G_CALLBACK(on_rtpbin_request_pt_map), transport_agent);
     g_signal_connect(priv->rtpbin, "request-aux-sender", G_CALLBACK(on_rtpbin_request_aux_sender), transport_agent);


### PR DESCRIPTION
These commits add support for:

* request-pt callback for rtpjitterbuffer that passes on the correct caps (clock-rate), see https://github.com/EricssonResearch/openwebrtc/issues/244#issuecomment-78531802
* using the pipeline clock instead of the system real-time clock, see https://github.com/EricssonResearch/openwebrtc/issues/244#issuecomment-78703289