### PR TITLE
Use ercolorspace on iOS for optimized ARM (including ARM64) colour space conversion

### DIFF
--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -565,6 +565,13 @@ static GstElement *owr_local_media_source_request_source(OwrMediaSource *media_s
             gst_caps_unref(device_caps);
             gst_object_unref(srcpad);
 
+#if defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+            /* Force NV12 on iOS else the source can negotiate BGRA
+             * ercolorspace can do NV12 -> BGRA and NV12 -> I420 which is what
+             * is needed for Bowser */
+            gst_caps_set_simple(source_caps, "format", G_TYPE_STRING, "NV12", NULL);
+#endif
+
             CREATE_ELEMENT(capsfilter, "capsfilter", "video-source-capsfilter");
             g_object_set(capsfilter, "caps", source_caps, NULL);
             gst_caps_unref(source_caps);

--- a/local/owr_video_renderer.c
+++ b/local/owr_video_renderer.c
@@ -50,12 +50,6 @@
 
 #define VIDEO_SINK "glimagesink"
 
-#if defined(__ANDROID__) || (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
-#define VIDEO_CONVERT "ercolorspace"
-#else
-#define VIDEO_CONVERT "videoconvert"
-#endif
-
 #define DEFAULT_WIDTH 0
 #define DEFAULT_HEIGHT 0
 #define DEFAULT_MAX_FRAMERATE 0.0

--- a/owr/owr.c
+++ b/owr/owr.c
@@ -104,7 +104,7 @@ GST_PLUGIN_STATIC_DECLARE(pulseaudio);
 GST_PLUGIN_STATIC_DECLARE(video4linux2);
 #endif
 
-#if defined(__ANDROID__) || (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
+#if defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 GST_PLUGIN_STATIC_DECLARE(ercolorspace);
 #endif
 #endif
@@ -230,7 +230,7 @@ void owr_init(GMainContext *main_context)
     GST_PLUGIN_STATIC_REGISTER(pulseaudio);
     GST_PLUGIN_STATIC_REGISTER(video4linux2);
 #endif
-#if defined(__ANDROID__) || (defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__))
+#if defined(__APPLE__) && TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
     GST_PLUGIN_STATIC_REGISTER(ercolorspace);
 #endif
 

--- a/owr/owr_media_source.c
+++ b/owr/owr_media_source.c
@@ -46,9 +46,9 @@
 #include <TargetConditionals.h>
 #endif
 
-#if defined(__APPLE__) && !TARGET_IPHONE_SIMULATOR && !defined(__arm64__)
+#if defined(__APPLE__) && !TARGET_IPHONE_SIMULATOR
 #if TARGET_OS_IPHONE
-#define VIDEO_CONVERT "videoconvert"
+#define VIDEO_CONVERT "ercolorspace"
 #else
 #define VIDEO_CONVERT "videoconvert"
 #endif


### PR DESCRIPTION
I've tested this with NativeDemo (for NV12 -> I420 with VP8) and Bowser (for NV12 -> BGRA for image renderer).