### PR TITLE
video_payload: added rotation and mirror properties

### DIFF
--- a/transport/owr_video_payload.c
+++ b/transport/owr_video_payload.c
@@ -46,6 +46,8 @@ GST_DEBUG_CATEGORY_EXTERN(_owrvideopayload_debug);
 #define DEFAULT_WIDTH 0
 #define DEFAULT_HEIGHT 0
 #define DEFAULT_FRAMERATE 0.0
+#define DEFAULT_ROTATION 0
+#define DEFAULT_MIRROR FALSE
 
 #define OWR_VIDEO_PAYLOAD_GET_PRIVATE(obj)    (G_TYPE_INSTANCE_GET_PRIVATE((obj), OWR_TYPE_VIDEO_PAYLOAD, OwrVideoPayloadPrivate))
 
@@ -57,6 +59,8 @@ struct _OwrVideoPayloadPrivate {
     guint width;
     guint height;
     gdouble framerate;
+    gint rotation;
+    gboolean mirror;
 };
 
 
@@ -68,6 +72,8 @@ enum {
     PROP_WIDTH,
     PROP_HEIGHT,
     PROP_FRAMERATE,
+    PROP_ROTATION,
+    PROP_MIRROR,
 
     N_PROPERTIES,
 
@@ -108,6 +114,14 @@ static void owr_video_payload_set_property(GObject *object, guint property_id, c
         priv->framerate = g_value_get_double(value);
         break;
 
+    case PROP_ROTATION:
+        priv->rotation = g_value_get_uint(value);
+        break;
+
+    case PROP_MIRROR:
+        priv->mirror = g_value_get_boolean(value);
+        break;
+
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
         break;
@@ -143,6 +157,14 @@ static void owr_video_payload_get_property(GObject *object, guint property_id, G
 
     case PROP_FRAMERATE:
         g_value_set_double(value, priv->framerate);
+        break;
+
+    case PROP_ROTATION:
+        g_value_set_uint(value, priv->rotation);
+        break;
+
+    case PROP_MIRROR:
+        g_value_set_boolean(value, priv->mirror);
         break;
 
     case PROP_MEDIA_TYPE:
@@ -192,6 +214,16 @@ static void owr_video_payload_class_init(OwrVideoPayloadClass *klass)
         0.0, G_MAXDOUBLE, DEFAULT_FRAMERATE,
         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_STATIC_STRINGS);
 
+    obj_properties[PROP_ROTATION] = g_param_spec_uint("rotation", "rotation",
+        "Clockwise video rotation in multiple of 90 degrees"
+        " (NOTE: currently only works for send payloads)", 0, 3, DEFAULT_ROTATION,
+        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+    obj_properties[PROP_MIRROR] = g_param_spec_boolean("mirror", "mirror",
+        "Whether the video should be mirror around the y-axis "
+        "(NOTE: currently only works for send payloads)", DEFAULT_MIRROR,
+        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
     g_object_class_install_properties(gobject_class, N_PROPERTIES, obj_properties);
 }
 
@@ -203,6 +235,8 @@ static void owr_video_payload_init(OwrVideoPayload *video_payload)
     video_payload->priv->width = DEFAULT_WIDTH;
     video_payload->priv->height = DEFAULT_HEIGHT;
     video_payload->priv->framerate = DEFAULT_FRAMERATE;
+    video_payload->priv->rotation = DEFAULT_ROTATION;
+    video_payload->priv->mirror = DEFAULT_MIRROR;
 }
 
 OwrPayload * owr_video_payload_new(OwrCodecType codec_type, guint payload_type, guint clock_rate,


### PR DESCRIPTION
Don't merge this, it doesn't  work :stuck_out_tongue:

We want to have something like this, but using gl whenever we can, and I'm really not sure about the property names, and if they should be on the session or someplace else.

Regardless of those issues, this still doesn't really work, the video is rotated and it works with test-send-receive for a while, but then the pipeline stops. So far I've seen two different errors, one in the srtp-encoder, and the other because an rtpbin pad was added, and then a second receive bin is added and there's a name clash.

What triggers presumably both of those errors is that the ssrc is sometimes changed when the video is rotated (I've verified that that's the case) so the question is why? :)

Setting a rotation that is perpendicular to the current one will trigger a caps renegotiation, since the width and height are swapped, but why does this cause the ssrc to be changed? (if that's even the case)

I've also seen something similar to this on Android when swapping send sources, so it's probably a broader issue.