### PR TITLE
webrtc.js: Opus encoding name is lower case

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -47,7 +47,7 @@
 
     var defaultPayloads = {
         "audio" : [
-            { "encodingName": "OPUS", "type": 111, "clockRate": 48000, "channels": 2 },
+            { "encodingName": "opus", "type": 111, "clockRate": 48000, "channels": 2 },
             { "encodingName": "PCMA", "type": 8, "clockRate": 8000, "channels": 1 },
             { "encodingName": "PCMU", "type": 0, "clockRate": 8000, "channels": 1 },
         ],


### PR DESCRIPTION
As far as I can tell, the Opus encoding name should be and has always been lower case:
https://tools.ietf.org/html/draft-ietf-payload-rtp-opus-11

Firefox is ignoring Opus if it's in upper case, and is choosing PCMA/PCMU instead.

@adam-be @pererikb @stefhak Does this make sense?