### PR TITLE
Adjust codec settings to be faster / lower quality

### DIFF
--- a/transport/owr_payload.c
+++ b/transport/owr_payload.c
@@ -391,8 +391,16 @@ GstElement * _owr_payload_create_encoder(OwrPayload *payload)
         } else if (!strcmp(factory_name, "vtenc_h264")) {
             g_object_bind_property_full(payload, "bitrate", encoder, "bitrate", G_BINDING_SYNC_CREATE,
                 binding_transform_to_kbps, NULL, NULL, NULL);
-            g_object_set(encoder, "allow-frame-reordering", FALSE, "realtime", TRUE,
-                "quality", 0.5, "max-keyframe-interval", G_MAXINT, NULL);
+            g_object_set(encoder,
+                "allow-frame-reordering", FALSE,
+                "realtime", TRUE,
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+                "quality", 0.0,
+#else
+                "quality", 0.5,
+#endif
+                "max-keyframe-interval", G_MAXINT,
+                NULL);
         } else {
             /* Assume bits/s instead of kbit/s */
             g_object_bind_property(payload, "bitrate", encoder, "bitrate", G_BINDING_SYNC_CREATE);

--- a/transport/owr_payload.c
+++ b/transport/owr_payload.c
@@ -382,6 +382,7 @@ GstElement * _owr_payload_create_encoder(OwrPayload *payload)
         if (!strcmp(factory_name, "openh264enc")) {
             g_object_set(encoder, "gop-size", 0, NULL);
             gst_util_set_object_arg(G_OBJECT(encoder), "rate-control", "bitrate");
+            gst_util_set_object_arg(G_OBJECT(encoder), "complexity", "low");
             g_object_bind_property(payload, "bitrate", encoder, "bitrate", G_BINDING_SYNC_CREATE);
         } else if (!strcmp(factory_name, "x264enc")) {
             g_object_bind_property_full(payload, "bitrate", encoder, "bitrate", G_BINDING_SYNC_CREATE,

--- a/transport/owr_payload.c
+++ b/transport/owr_payload.c
@@ -386,7 +386,8 @@ GstElement * _owr_payload_create_encoder(OwrPayload *payload)
         } else if (!strcmp(factory_name, "x264enc")) {
             g_object_bind_property_full(payload, "bitrate", encoder, "bitrate", G_BINDING_SYNC_CREATE,
                 binding_transform_to_kbps, NULL, NULL, NULL);
-            g_object_set(encoder, "tune", 0x04 /* zero-latency */, NULL);
+            gst_util_set_object_arg(encoder, "speed-preset", "ultrafast");
+            gst_util_set_object_arg(encoder, "tune", "fastdecode+zerolatency");
         } else if (!strcmp(factory_name, "vtenc_h264")) {
             g_object_bind_property_full(payload, "bitrate", encoder, "bitrate", G_BINDING_SYNC_CREATE,
                 binding_transform_to_kbps, NULL, NULL, NULL);


### PR DESCRIPTION
vtenc_h264 - set quality to 0.0 on mobile and 0.5 on desktop. Hopefully this uses less battery / reduces latency on iOS but needs to be tested.

x264enc - set tune and speed-preset options to encode much more quickly therefore lower latency and less CPU usage

openh264enc - reduce encoding complexity to low which should improve encoding performance / latency on Android and Linux.