### PR TITLE
Revert "OwrTransportAgent: Sync RTP, don't sync RTCP"

### DIFF
--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -1030,9 +1030,9 @@ static GstElement *add_nice_element(OwrTransportAgent *transport_agent, guint st
         ? NICE_COMPONENT_TYPE_RTCP : NICE_COMPONENT_TYPE_RTP, NULL);
 
     if (is_sink) {
-        g_object_set(nice_element, "enable-last-sample", FALSE, NULL);
+        g_object_set(nice_element, "enable-last-sample", FALSE, "async", FALSE, NULL);
         if (is_rtcp)
-            g_object_set(nice_element, "sync", FALSE, "async", FALSE, NULL);
+            g_object_set(nice_element, "sync", FALSE, NULL);
     }
 
     added_ok = gst_bin_add(GST_BIN(bin), nice_element);


### PR DESCRIPTION
This change broke streams when inactive streams where present. e.g. Adding two sessions but only setting a send source on one of them.

There's probably another fix for that, but what was the reason we wanted the RTP nice sink to have sync set in the first place?