### PR TITLE
local: do not chain "list closure mergers"

### DIFF
--- a/local/owr_device_list.c
+++ b/local/owr_device_list.c
@@ -94,28 +94,26 @@ static void call_closure_with_list_later(GClosure *callback, GList *list)
 }
 #endif
 
-void _owr_get_capture_devices(OwrMediaType types, GClosure *callback)
+void _owr_get_capture_devices(OwrMediaType types, GClosure *list_closure_merger)
 {
-    GClosure *merger;
+    g_return_if_fail(list_closure_merger);
 
-    g_return_if_fail(callback);
+    if (G_CLOSURE_NEEDS_MARSHAL(list_closure_merger))
+        g_closure_set_marshal(list_closure_merger, g_cclosure_marshal_generic);
 
-    if (G_CLOSURE_NEEDS_MARSHAL(callback))
-        g_closure_set_marshal(callback, g_cclosure_marshal_generic);
-
-    merger = _owr_utils_list_closure_merger_new(callback, (GDestroyNotify) g_object_unref);
+    g_closure_ref(list_closure_merger);
 
     if (types & OWR_MEDIA_TYPE_VIDEO) {
-        g_closure_ref(merger);
-        _owr_schedule_with_user_data((GSourceFunc) enumerate_video_source_devices, merger);
+        g_closure_ref(list_closure_merger);
+        _owr_schedule_with_user_data((GSourceFunc) enumerate_video_source_devices, list_closure_merger);
     }
 
     if (types & OWR_MEDIA_TYPE_AUDIO) {
-        g_closure_ref(merger);
-        _owr_schedule_with_user_data((GSourceFunc) enumerate_audio_source_devices, merger);
+        g_closure_ref(list_closure_merger);
+        _owr_schedule_with_user_data((GSourceFunc) enumerate_audio_source_devices, list_closure_merger);
     }
 
-    g_closure_unref(merger);
+    g_closure_unref(list_closure_merger);
 }
 
 

--- a/local/owr_device_list_private.h
+++ b/local/owr_device_list_private.h
@@ -40,9 +40,9 @@
 G_BEGIN_DECLS
 
 /*
- * Callback signature is (GList *owrMediaSources, gpointer user_data)
+ * The final callback of the list_closure_merger has signature (GList *owrMediaSources, gpointer user_data)
  */
-void _owr_get_capture_devices(OwrMediaType types, GClosure *callback);
+void _owr_get_capture_devices(OwrMediaType types, GClosure *list_closure_merger);
 
 G_END_DECLS
 

--- a/local/owr_local.c
+++ b/local/owr_local.c
@@ -120,16 +120,13 @@ void owr_get_capture_sources(OwrMediaType types, OwrCaptureSourcesCallback callb
     closure = g_cclosure_new(G_CALLBACK(callback), user_data, NULL);
     g_closure_set_marshal(closure, g_cclosure_marshal_generic);
 
+    merger = _owr_utils_list_closure_merger_new(closure, (GDestroyNotify) g_object_unref);
+    _owr_get_capture_devices(types, merger);
+
     if (g_getenv("OWR_USE_TEST_SOURCES")) {
-        merger = _owr_utils_list_closure_merger_new(closure, (GDestroyNotify) g_object_unref);
-
-        g_closure_ref(merger);
-        _owr_get_capture_devices(types, merger);
-
         g_closure_ref(merger);
         _owr_utils_call_closure_with_list(merger, get_test_sources(types));
+    }
 
-        g_closure_unref(merger);
-    } else
-        _owr_get_capture_devices(types, closure);
+    g_closure_unref(merger);
 }


### PR DESCRIPTION
owr_get_capture_sources() (in local/owr_local.c) uses
the private function _owr_get_capture_devices() (in local/owr_device_list.c).

When test sources are included are "list closure mergers" chained.
But that is an error which most likely crashes the
application (typically Segmentation fault).

A "list closure merger" is not designed/implemented to support chaining with
another "list closure merger".
The main reason is that the overall design relies on that you concat a list
when you merge it, which is not a copy operation. Instead are the elements
used directly. If M2 transfers its list L2 to M1, L2 is added to the end
of M1's list L1, but L2 will be intact.

After a "list closure merger" has delivered the  concatenated list
to its "final callback closure" it will free the list.
And moreover, if there is a free-func defined, it will be called on every
element's data. This works fine if you are using only one "list closure merger".
But if you chain them, another "list closure merger" will release a list
which has already been released (remember: the elements are used directly) by
an associated "list closure merger".

(A few details: callback_merger_on_destroy_data() (in owr/utils.c) calls its
associated closure using _owr_utils_call_closure_with_list() (in owr/utils.c).
And _owr_utils_call_closure_with_list() transfers the list to the closure
and unreferences the closure. If the closure is a "list closure merger"
(there are chained "list closure mergers") and its refcount reaches 0,
which it does in the current code, its callback_merger_on_destroy_data() will be called.
Note that after the associated closure has been called,
callback_merger_on_destroy_data() will release the list.)

The new solution is simple and uses only one "list closure merger".