### PR TITLE
utils: change the ownership semantics of the closure merger

### DIFF
--- a/local/owr_local.c
+++ b/local/owr_local.c
@@ -121,13 +121,19 @@ void owr_get_capture_sources(OwrMediaType types, OwrCaptureSourcesCallback callb
     g_closure_set_marshal(closure, g_cclosure_marshal_generic);
 
     if (g_getenv("OWR_USE_TEST_SOURCES")) {
-        merger = _owr_utils_list_closure_merger_new(closure, (GDestroyNotify) g_object_unref);
+        GList *sources;
+
+        merger = _owr_utils_list_closure_merger_new(closure,
+            (GCopyFunc) g_object_ref,
+            (GDestroyNotify) g_object_unref);
 
         g_closure_ref(merger);
         _owr_get_capture_devices(types, merger);
 
         g_closure_ref(merger);
-        _owr_utils_call_closure_with_list(merger, get_test_sources(types));
+        sources = get_test_sources(types);
+        _owr_utils_call_closure_with_list(merger, sources);
+        g_list_free_full(sources, g_object_unref);
 
         g_closure_unref(merger);
     } else

--- a/owr/owr_utils.h
+++ b/owr/owr_utils.h
@@ -42,7 +42,9 @@ G_BEGIN_DECLS
 void *_owr_require_symbols(void);
 OwrCodecType _owr_caps_to_codec_type(GstCaps *caps);
 void _owr_utils_call_closure_with_list(GClosure *callback, GList *list);
-GClosure *_owr_utils_list_closure_merger_new(GClosure *final_callback, GDestroyNotify list_item_destroy);
+GClosure *_owr_utils_list_closure_merger_new(GClosure *final_callback,
+    GCopyFunc list_item_copy,
+    GDestroyNotify list_item_destroy);
 
 /* FIXME: This should be removed when the GStreamer required version
  * is 1.6 and gst_caps_foreach() can be used.


### PR DESCRIPTION
Make the closure merger always copy the input lists. This makes it
possible to safely nest closure mergers, like it's done by
owr_get_capture_sources when OWR_USE_TEST_SOURCES is set.

Before this change owr_get_capture_sources would end up nesting
closure mergers which lead to a memory corruption since the inner
merger (used internally by _owr_get_capture_devices) would deallocate
part of the list owned by the outer merger (the one instantiated by
owr_get_capture_sources).