### PR TITLE
webrtc_js: Add parameter to H264 to allow level asymmetry

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -54,7 +54,7 @@
         "video": [
             { "encodingName": "H264", "type": 103, "clockRate": 90000,
                 "ccmfir": true, "nackpli": true, /* "nack": true, */
-                "parameters": { "packetizationMode": 1 } },
+                "parameters": { "levelAsymmetryAllowed": 1, "packetizationMode": 1 } },
 /* FIXME: Enable when Chrome can handle an offer with RTX for H264
             { "encodingName": "RTX", "type": 123, "clockRate": 90000,
                 "parameters": { "apt": 103, "rtxTime": 200 } },*/


### PR DESCRIPTION
This makes recent Firefox accept H264 in our offer