### PR TITLE
bugfix in findInArrayById: missplaced semicolon.

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -1086,7 +1086,7 @@
 
         function findInArrayById(array, id) {
             for (var i = 0; i < array.length; i++)
-                if (array[i].id == id);
+                if (array[i].id == id)
                     return array[i];
             return null;
         }


### PR DESCRIPTION
This looked a lot like a bug..  I have not tested if it give some strange effect though.. but I guess it should not.