### PR TITLE
OwrURISourceAgent: OwrURISource: New API to play from a URI

### DIFF
--- a/local/Makefile.am
+++ b/local/Makefile.am
@@ -25,6 +25,8 @@ libopenwebrtc_local_la_SOURCES = \
     owr_video_renderer.c \
     owr_image_renderer.c \
     owr_image_server.c \
+    owr_uri_source.c \
+    owr_uri_source_agent.c \
     owr_window_registry.c \
     owr_device_list.c
 
@@ -46,11 +48,14 @@ include_HEADERS = \
     owr_video_renderer.h \
     owr_image_renderer.h \
     owr_image_server.h \
+    owr_uri_source.h \
+    owr_uri_source_agent.h \
     owr_window_registry.h
 
 noinst_HEADERS = \
     owr_local_media_source_private.h \
     owr_image_renderer_private.h \
+    owr_uri_source_private.h \
     owr_window_registry_private.h
 
 if TARGET_APPLE

--- a/local/owr_uri_source.c
+++ b/local/owr_uri_source.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2014-2015, Ericsson AB. All rights reserved.
+ * Copyright (c) 2014, Centricular Ltd
+ *     Author: Sebastian Dröge <sebastian@centricular.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+/*/
+\*\ OwrURISource
+/*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "owr_uri_source.h"
+
+#include "owr_media_source.h"
+#include "owr_media_source_private.h"
+#include "owr_private.h"
+#include "owr_uri_source_private.h"
+#include "owr_types.h"
+#include "owr_utils.h"
+
+#include <gst/gst.h>
+
+#define OWR_URI_SOURCE_GET_PRIVATE(obj)    (G_TYPE_INSTANCE_GET_PRIVATE((obj), OWR_TYPE_URI_SOURCE, OwrURISourcePrivate))
+
+G_DEFINE_TYPE(OwrURISource, owr_uri_source, OWR_TYPE_MEDIA_SOURCE)
+
+struct _OwrURISourcePrivate {
+    guint stream_id;
+};
+
+static void owr_uri_source_class_init(OwrURISourceClass *klass)
+{
+    g_type_class_add_private(klass, sizeof(OwrURISourcePrivate));
+}
+
+static void owr_uri_source_init(OwrURISource *source)
+{
+    source->priv = OWR_URI_SOURCE_GET_PRIVATE(source);
+
+    source->priv->stream_id = 0;
+}
+
+#define LINK_ELEMENTS(a, b) \
+    if (!gst_element_link(a, b)) \
+        GST_ERROR("Failed to link " #a " -> " #b);
+
+OwrMediaSource *_owr_uri_source_new(OwrMediaType media_type,
+    guint stream_id, OwrCodecType codec_type, gpointer uridecodebin_ptr)
+{
+    GstElement *uridecodebin = GST_ELEMENT(uridecodebin_ptr);
+    OwrURISource *source;
+    OwrURISourcePrivate *priv;
+    GEnumClass *enum_class;
+    GEnumValue *enum_value;
+    gchar *name;
+    GstElement *uri_pipeline;
+    GstElement *source_bin, *tee;
+    GstElement *fakesink, *queue;
+    GstPad *srcpad, *sinkpad, *ghostpad;
+    gchar *pad_name, *bin_name;
+
+    enum_class = G_ENUM_CLASS(g_type_class_ref(OWR_TYPE_MEDIA_TYPE));
+    enum_value = g_enum_get_value(enum_class, media_type);
+    name = g_strdup_printf("%s stream, id: %u", enum_value ? enum_value->value_nick : "unknown", stream_id);
+    g_type_class_unref(enum_class);
+
+    source = g_object_new(OWR_TYPE_URI_SOURCE,
+        "name", name,
+        "media-type", media_type,
+        NULL);
+
+    priv = source->priv;
+    priv->stream_id = stream_id;
+    g_free(name);
+
+    _owr_media_source_set_codec(OWR_MEDIA_SOURCE(source), codec_type);
+
+    /* create source tee and everything */
+    if (media_type == OWR_MEDIA_TYPE_VIDEO)
+        bin_name = g_strdup_printf("video-src-%u-%u", codec_type, stream_id);
+    else if (media_type == OWR_MEDIA_TYPE_AUDIO)
+        bin_name = g_strdup_printf("audio-src-%u-%u", codec_type, stream_id);
+    else
+        g_assert_not_reached();
+    pad_name = g_strdup_printf("src_%u", stream_id);
+
+    source_bin = gst_bin_new(bin_name);
+    _owr_media_source_set_source_bin(OWR_MEDIA_SOURCE(source), source_bin);
+    tee = gst_element_factory_make("tee", "tee");
+    _owr_media_source_set_source_tee(OWR_MEDIA_SOURCE(source), tee);
+    fakesink = gst_element_factory_make("fakesink", "fakesink");
+    g_object_set(fakesink, "async", FALSE, NULL);
+    queue = gst_element_factory_make("queue", "queue");
+    g_free(bin_name);
+
+    uri_pipeline = GST_ELEMENT(gst_element_get_parent(uridecodebin));
+    gst_bin_add_many(GST_BIN(source_bin), tee, queue, fakesink, NULL);
+    LINK_ELEMENTS(tee, queue);
+    LINK_ELEMENTS(queue, fakesink);
+    sinkpad = gst_element_get_static_pad(tee, "sink");
+    ghostpad = gst_ghost_pad_new("sink", sinkpad);
+    gst_object_unref(sinkpad);
+    gst_element_add_pad(source_bin, ghostpad);
+    gst_bin_add(GST_BIN(uri_pipeline), source_bin);
+    gst_element_sync_state_with_parent(source_bin);
+    gst_object_unref(uri_pipeline);
+
+    /* Link the uridecodebin to our tee */
+    srcpad = gst_element_get_static_pad(uridecodebin, pad_name);
+    g_free(pad_name);
+    if (gst_pad_link(srcpad, ghostpad) != GST_PAD_LINK_OK)
+        GST_ERROR("Failed to link source bin to the outside");
+
+    return OWR_MEDIA_SOURCE(source);
+}

--- a/local/owr_uri_source.h
+++ b/local/owr_uri_source.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-2015, Ericsson AB. All rights reserved.
+ * Copyright (c) 2014, Centricular Ltd
+ *     Author: Sebastian Dröge <sebastian@centricular.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+/*/
+\*\ OwrURISource
+/*/
+
+#ifndef __OWR_URI_SOURCE_H__
+#define __OWR_URI_SOURCE_H__
+
+#include "owr_media_source.h"
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define OWR_TYPE_URI_SOURCE            (owr_uri_source_get_type())
+#define OWR_URI_SOURCE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), OWR_TYPE_URI_SOURCE, OwrURISource))
+#define OWR_URI_SOURCE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), OWR_TYPE_URI_SOURCE, OwrURISourceClass))
+#define OWR_IS_URI_SOURCE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), OWR_TYPE_URI_SOURCE))
+#define OWR_IS_URI_SOURCE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), OWR_TYPE_URI_SOURCE))
+#define OWR_URI_SOURCE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj), OWR_TYPE_URI_SOURCE, OwrURISourceClass))
+
+typedef struct _OwrURISource        OwrURISource;
+typedef struct _OwrURISourceClass   OwrURISourceClass;
+typedef struct _OwrURISourcePrivate OwrURISourcePrivate;
+
+struct _OwrURISource {
+    OwrMediaSource parent_instance;
+
+    /*< private >*/
+    OwrURISourcePrivate *priv;
+};
+
+struct _OwrURISourceClass {
+    OwrMediaSourceClass parent_class;
+};
+
+GType owr_uri_source_get_type(void) G_GNUC_CONST;
+
+G_END_DECLS
+
+#endif /* __OWR_URI_SOURCE_H__ */

--- a/local/owr_uri_source_agent.c
+++ b/local/owr_uri_source_agent.c
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2014-2015, Ericsson AB. All rights reserved.
+ * Copyright (c) 2014, Centricular Ltd
+ *     Author: Sebastian Dröge <sebastian@centricular.com>
+ *     Author: Arun Raghavan <arun@centricular.com>
+ * Copyright (c) 2015, Collabora Ltd.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+/*/
+\*\ OwrURISourceAgent
+/*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "owr_uri_source_agent.h"
+
+#include "owr_private.h"
+#include "owr_uri_source.h"
+#include "owr_uri_source_private.h"
+#include "owr_utils.h"
+
+#include <gst/audio/audio.h>
+#include <gst/video/video.h>
+#include <gst/gst.h>
+#include <stdio.h>
+
+#define DEFAULT_URI NULL
+
+enum {
+    PROP_0,
+    PROP_URI,
+    N_PROPERTIES
+};
+
+enum {
+    SIGNAL_ON_NEW_SOURCE,
+
+    LAST_SIGNAL
+};
+
+static GParamSpec *obj_properties[N_PROPERTIES] = {NULL, };
+static guint uri_source_agent_signals[LAST_SIGNAL] = { 0 };
+static guint next_uri_source_agent_id = 1;
+
+#define OWR_URI_SOURCE_AGENT_GET_PRIVATE(obj)    (G_TYPE_INSTANCE_GET_PRIVATE((obj), OWR_TYPE_URI_SOURCE_AGENT, OwrURISourceAgentPrivate))
+
+G_DEFINE_TYPE(OwrURISourceAgent, owr_uri_source_agent, G_TYPE_OBJECT)
+
+struct _OwrURISourceAgentPrivate {
+    gchar *uri;
+    guint agent_id;
+    GstElement *pipeline, *uridecodebin;
+};
+
+static void owr_uri_source_agent_set_property(GObject *object, guint property_id,
+    const GValue *value, GParamSpec *pspec);
+static void owr_uri_source_agent_get_property(GObject *object, guint property_id,
+    GValue *value, GParamSpec *pspec);
+
+
+static void on_uridecodebin_pad_added(GstElement *uri_bin, GstPad *new_pad, OwrURISourceAgent *uri_source_agent);
+
+static void owr_uri_source_agent_finalize(GObject *object)
+{
+    OwrURISourceAgent *uri_source_agent = NULL;
+    OwrURISourceAgentPrivate *priv = NULL;
+
+    g_return_if_fail(_owr_is_initialized());
+
+    uri_source_agent = OWR_URI_SOURCE_AGENT(object);
+    priv = uri_source_agent->priv;
+
+    gst_element_set_state(priv->pipeline, GST_STATE_NULL);
+    gst_object_unref(priv->pipeline);
+
+    g_free(priv->uri);
+
+    G_OBJECT_CLASS(owr_uri_source_agent_parent_class)->finalize(object);
+}
+
+static void owr_uri_source_agent_class_init(OwrURISourceAgentClass *klass)
+{
+    GObjectClass *gobject_class;
+    g_type_class_add_private(klass, sizeof(OwrURISourceAgentPrivate));
+
+    gobject_class = G_OBJECT_CLASS(klass);
+
+    obj_properties[PROP_URI] = g_param_spec_string("uri",
+        "URI", "A URI pointing to media support by GStreamer's uridecodebin",
+        DEFAULT_URI, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+    /**
+    * OwrURISourceAgent::on-new-source:
+    * @uri_source_agent: the object which received the signal
+    * @source: (transfer none): the new source
+    *
+    * Notify of a new source for a #OwrURISourceAgent.
+    */
+    uri_source_agent_signals[SIGNAL_ON_NEW_SOURCE] = g_signal_new("on-new-source",
+        G_OBJECT_CLASS_TYPE(klass), G_SIGNAL_RUN_CLEANUP,
+        G_STRUCT_OFFSET(OwrURISourceAgentClass, on_new_source), NULL, NULL,
+        NULL, G_TYPE_NONE, 1, OWR_TYPE_MEDIA_SOURCE);
+
+
+    gobject_class->set_property = owr_uri_source_agent_set_property;
+    gobject_class->get_property = owr_uri_source_agent_get_property;
+    gobject_class->finalize = owr_uri_source_agent_finalize;
+
+    g_object_class_install_properties(gobject_class, N_PROPERTIES, obj_properties);
+}
+
+/* FIXME: Copy from owr/owr.c without any error handling whatsoever */
+static gboolean bus_call(GstBus *bus, GstMessage *msg, gpointer user_data)
+{
+    gboolean ret, is_warning = FALSE;
+    GstStateChangeReturn change_status;
+    gchar *message_type, *debug;
+    GError *error;
+    GstPipeline *pipeline = user_data;
+
+    g_return_val_if_fail(GST_IS_BUS(bus), TRUE);
+
+    (void)user_data;
+
+    switch (GST_MESSAGE_TYPE(msg)) {
+    case GST_MESSAGE_LATENCY:
+        ret = gst_bin_recalculate_latency(GST_BIN(pipeline));
+        g_warn_if_fail(ret);
+        break;
+
+    case GST_MESSAGE_CLOCK_LOST:
+        change_status = gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_PAUSED);
+        g_warn_if_fail(change_status != GST_STATE_CHANGE_FAILURE);
+        change_status = gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_PLAYING);
+        g_warn_if_fail(change_status != GST_STATE_CHANGE_FAILURE);
+        break;
+
+    case GST_MESSAGE_EOS:
+        /* FIXME - implement looping */
+        g_print("EOS\n");
+        break;
+
+    case GST_MESSAGE_WARNING:
+        is_warning = TRUE;
+
+    case GST_MESSAGE_ERROR:
+        if (is_warning) {
+            message_type = "Warning";
+            gst_message_parse_warning(msg, &error, &debug);
+        } else {
+            message_type = "Error";
+            gst_message_parse_error(msg, &error, &debug);
+        }
+
+        g_printerr("==== %s message start ====\n", message_type);
+        g_printerr("%s in element %s.\n", message_type, GST_OBJECT_NAME(msg->src));
+        g_printerr("%s: %s\n", message_type, error->message);
+        g_printerr("Debugging info: %s\n", (debug) ? debug : "none");
+
+        g_printerr("==== %s message stop ====\n", message_type);
+        /*GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline.dot");*/
+
+        g_error_free(error);
+        g_free(debug);
+        break;
+
+    default:
+        break;
+    }
+
+    return TRUE;
+}
+
+static void owr_uri_source_agent_init(OwrURISourceAgent *uri_source_agent)
+{
+    OwrURISourceAgentPrivate *priv;
+    GstBus *bus;
+    GSource *bus_source;
+    gchar *pipeline_name, *uridecodebin_name;
+
+    uri_source_agent->priv = priv = OWR_URI_SOURCE_AGENT_GET_PRIVATE(uri_source_agent);
+
+    priv->uri = DEFAULT_URI;
+    priv->agent_id = next_uri_source_agent_id++;
+
+    g_return_if_fail(_owr_is_initialized());
+
+    pipeline_name = g_strdup_printf("uri-source-agent-%u", priv->agent_id);
+    priv->pipeline = gst_pipeline_new(pipeline_name);
+    g_free(pipeline_name);
+
+#ifdef OWR_DEBUG
+    g_signal_connect(priv->pipeline, "deep-notify", G_CALLBACK(_owr_deep_notify), NULL);
+#endif
+
+    bus = gst_pipeline_get_bus(GST_PIPELINE(priv->pipeline));
+    bus_source = gst_bus_create_watch(bus);
+    g_source_set_callback(bus_source, (GSourceFunc) bus_call, priv->pipeline, NULL);
+    g_source_attach(bus_source, _owr_get_main_context());
+    g_source_unref(bus_source);
+
+    uridecodebin_name = g_strdup_printf("uridecodebin-%u", priv->agent_id);
+    priv->uridecodebin = gst_element_factory_make("uridecodebin", uridecodebin_name);
+    g_free(uridecodebin_name);
+    g_signal_connect(priv->uridecodebin, "pad-added", G_CALLBACK(on_uridecodebin_pad_added), uri_source_agent);
+
+    gst_bin_add(GST_BIN(priv->pipeline), priv->uridecodebin);
+}
+
+static void owr_uri_source_agent_set_property(GObject *object, guint property_id,
+    const GValue *value, GParamSpec *pspec)
+{
+    OwrURISourceAgent *uri_source_agent;
+    OwrURISourceAgentPrivate *priv;
+
+    g_return_if_fail(object);
+    uri_source_agent = OWR_URI_SOURCE_AGENT(object);
+    priv = uri_source_agent->priv;
+
+    switch (property_id) {
+    case PROP_URI:
+        g_free(priv->uri);
+        priv->uri = g_value_dup_string(value);
+        g_object_set(priv->uridecodebin, "uri", priv->uri, NULL);
+        gst_element_set_state(priv->pipeline, GST_STATE_PAUSED);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+        break;
+    }
+}
+
+static void owr_uri_source_agent_get_property(GObject *object, guint property_id,
+    GValue *value, GParamSpec *pspec)
+{
+    OwrURISourceAgent *uri_source_agent;
+    OwrURISourceAgentPrivate *priv;
+
+    g_return_if_fail(object);
+    uri_source_agent = OWR_URI_SOURCE_AGENT(object);
+    priv = uri_source_agent->priv;
+
+    switch (property_id) {
+    case PROP_URI:
+        g_value_set_string(value, priv->uri);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+        break;
+    }
+}
+
+OwrURISourceAgent * owr_uri_source_agent_new(const gchar *uri)
+{
+    gchar *scheme;
+
+    scheme = g_uri_parse_scheme(uri);
+    if (!scheme) {
+        GST_WARNING("Invalid URI: %s", uri ? uri : "");
+        return NULL;
+    }
+
+    g_free(scheme);
+
+    return g_object_new(OWR_TYPE_URI_SOURCE_AGENT, "uri", uri,
+        NULL);
+}
+
+static gboolean emit_on_new_source(GHashTable *args)
+{
+    OwrURISourceAgent *uri_source_agent;
+    OwrMediaSource *source;
+
+    uri_source_agent = g_hash_table_lookup(args, "uri-source-agent");
+    source = g_hash_table_lookup(args, "source");
+
+    g_signal_emit_by_name(uri_source_agent, "on-new-source", source);
+
+    g_hash_table_unref(args);
+    return FALSE;
+}
+
+static void signal_new_source(OwrMediaType type, OwrURISourceAgent *uri_source_agent,
+    guint stream_id, OwrCodecType codec_type)
+{
+    OwrMediaSource *source;
+    GHashTable *args;
+
+    g_return_if_fail(OWR_IS_URI_SOURCE_AGENT(uri_source_agent));
+
+    source = _owr_uri_source_new(type, stream_id, codec_type,
+        uri_source_agent->priv->uridecodebin);
+
+    g_return_if_fail(source);
+
+    args = g_hash_table_new(g_str_hash, g_str_equal);
+    g_hash_table_insert(args, "uri-source-agent", uri_source_agent);
+    g_hash_table_insert(args, "source", source);
+
+    _owr_schedule_with_hash_table((GSourceFunc)emit_on_new_source, args);
+}
+
+static void on_uridecodebin_pad_added(GstElement *uridecodebin, GstPad *new_pad, OwrURISourceAgent *uri_source_agent)
+{
+    gchar *new_pad_name;
+    OwrMediaType media_type = OWR_MEDIA_TYPE_UNKNOWN;
+    guint stream_id = 0;
+    GstCaps *caps, *audio_raw_caps, *video_raw_caps;
+
+    g_return_if_fail(GST_IS_BIN(uridecodebin));
+    g_return_if_fail(GST_IS_PAD(new_pad));
+    g_return_if_fail(OWR_IS_URI_SOURCE_AGENT(uri_source_agent));
+
+    new_pad_name = gst_pad_get_name(new_pad);
+
+    sscanf(new_pad_name, "src_%u", &stream_id);
+    caps = gst_pad_get_current_caps(new_pad);
+
+    audio_raw_caps = gst_caps_from_string("audio/x-raw");
+    video_raw_caps = gst_caps_from_string("video/x-raw");
+
+    if (gst_caps_can_intersect(caps, audio_raw_caps))
+        media_type = OWR_MEDIA_TYPE_AUDIO;
+    else if (gst_caps_can_intersect(caps, video_raw_caps))
+        media_type = OWR_MEDIA_TYPE_VIDEO;
+
+    gst_caps_unref(audio_raw_caps);
+    gst_caps_unref(video_raw_caps);
+
+    if (media_type != OWR_MEDIA_TYPE_UNKNOWN)
+        signal_new_source(media_type, uri_source_agent, stream_id, OWR_CODEC_TYPE_NONE);
+
+    g_free(new_pad_name);
+    gst_caps_unref(caps);
+}
+
+gchar * owr_uri_source_agent_get_dot_data(OwrURISourceAgent *uri_source_agent)
+{
+    g_return_val_if_fail(OWR_IS_URI_SOURCE_AGENT(uri_source_agent), NULL);
+    g_return_val_if_fail(uri_source_agent->priv->pipeline, NULL);
+
+#if GST_CHECK_VERSION(1, 5, 0)
+    return gst_debug_bin_to_dot_data(GST_BIN(uri_source_agent->priv->pipeline), GST_DEBUG_GRAPH_SHOW_ALL);
+#else
+    return g_strdup("");
+#endif
+}
+
+gboolean owr_uri_source_agent_play(OwrURISourceAgent *uri_source_agent)
+{
+    return gst_element_set_state(uri_source_agent->priv->pipeline,
+        GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE;
+}
+
+
+gboolean owr_uri_source_agent_pause(OwrURISourceAgent *uri_source_agent)
+{
+    return gst_element_set_state(uri_source_agent->priv->pipeline,
+        GST_STATE_PAUSED) != GST_STATE_CHANGE_FAILURE;
+}

--- a/local/owr_uri_source_agent.h
+++ b/local/owr_uri_source_agent.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014-2015, Ericsson AB. All rights reserved.
+ * Copyright (c) 2014, Centricular Ltd
+ *     Author: Sebastian Dröge <sebastian@centricular.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+/*/
+\*\ OwrURISourceAgent
+/*/
+
+#ifndef __OWR_URI_SOURCE_AGENT_H__
+#define __OWR_URI_SOURCE_AGENT_H__
+
+#include "owr_types.h"
+#include "owr_uri_source.h"
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define OWR_TYPE_URI_SOURCE_AGENT            (owr_uri_source_agent_get_type())
+#define OWR_URI_SOURCE_AGENT(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), OWR_TYPE_URI_SOURCE_AGENT, OwrURISourceAgent))
+#define OWR_URI_SOURCE_AGENT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), OWR_TYPE_URI_SOURCE_AGENT, OwrURISourceAgentClass))
+#define OWR_IS_URI_SOURCE_AGENT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), OWR_TYPE_URI_SOURCE_AGENT))
+#define OWR_IS_URI_SOURCE_AGENT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), OWR_TYPE_URI_SOURCE_AGENT))
+#define OWR_URI_SOURCE_AGENT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj), OWR_TYPE_URI_SOURCE_AGENT, OwrURISourceAgentClass))
+
+typedef struct _OwrURISourceAgent        OwrURISourceAgent;
+typedef struct _OwrURISourceAgentClass   OwrURISourceAgentClass;
+typedef struct _OwrURISourceAgentPrivate OwrURISourceAgentPrivate;
+
+struct _OwrURISourceAgent {
+    GObject parent_instance;
+
+    /*< private >*/
+    OwrURISourceAgentPrivate *priv;
+};
+
+/**
+ * OwrURISourceAgentClass:
+ * @parent_class: the GObject parent
+ * @on_new_source: emitted to notify of a new source
+ *
+ * The URI source agent class.
+ */
+struct _OwrURISourceAgentClass {
+    GObjectClass parent_class;
+
+    /* signals */
+    void (*on_new_source)(OwrURISourceAgent *uri_source_agent, OwrMediaSource *source);
+};
+
+GType owr_uri_source_agent_get_type(void) G_GNUC_CONST;
+
+OwrURISourceAgent * owr_uri_source_agent_new(const gchar *uri);
+gchar * owr_uri_source_agent_get_dot_data(OwrURISourceAgent *uri_source_agent);
+
+gboolean owr_uri_source_agent_play(OwrURISourceAgent *uri_source_agent);
+gboolean owr_uri_source_agent_pause(OwrURISourceAgent *uri_source_agent);
+
+G_END_DECLS
+
+#endif /* __OWR_URI_SOURCE_AGENT_H__ */

--- a/local/owr_uri_source_private.h
+++ b/local/owr_uri_source_private.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014-2015, Ericsson AB. All rights reserved.
+ * Copyright (c) 2014, Centricular Ltd
+ *     Author: Sebastian Dröge <sebastian@centricular.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+/*/
+\*\ OwrURISource private
+/*/
+
+#ifndef __OWR_URI_SOURCE_PRIVATE_H__
+#define __OWR_URI_SOURCE_PRIVATE_H__
+
+#include "owr_media_source.h"
+#include "owr_types.h"
+
+#ifndef __GTK_DOC_IGNORE__
+
+G_BEGIN_DECLS
+
+OwrMediaSource *_owr_uri_source_new(OwrMediaType media_type,
+    guint stream_id, OwrCodecType codec_type, gpointer uridecodebin);
+
+G_END_DECLS
+
+#endif /* __GTK_DOC_IGNORE__ */
+
+#endif /* __OWR_URI_SOURCE_PRIVATE_H__ */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,6 +22,7 @@ bin_PROGRAMS = \
     test-data-channel \
     test-init \
     test-bus \
+    test-uri \
     test-client
 
 if OWR_GST
@@ -123,6 +124,22 @@ test_client_CFLAGS = \
     -I$(top_srcdir)/owr
 
 test_client_LDADD = \
+    $(JSON_GLIB_LIBS) \
+    $(LIBSOUP_LIBS) \
+    $(GLIB_LIBS) \
+    $(top_builddir)/owr/libopenwebrtc.la
+
+test_uri_SOURCES = test_uri.c test_utils.c
+
+test_uri_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(JSON_GLIB_CFLAGS) \
+    $(LIBSOUP_CFLAGS) \
+    -I$(top_srcdir)/local \
+    -I$(top_srcdir)/transport \
+    -I$(top_srcdir)/owr
+
+test_uri_LDADD = \
     $(JSON_GLIB_LIBS) \
     $(LIBSOUP_LIBS) \
     $(GLIB_LIBS) \

--- a/tests/test_uri.c
+++ b/tests/test_uri.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2014-2015, Ericsson AB. All rights reserved.
+ * Copyright (c) 2014, Centricular Ltd
+ *     Author: Sebastian Dröge <sebastian@centricular.com>
+ *     Author: Arun Raghavan <arun@centricular.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE 1
+
+#include "owr.h"
+#include "owr_audio_renderer.h"
+#include "owr_local.h"
+#include "owr_media_renderer.h"
+#include "owr_media_source.h"
+#include "owr_uri_source.h"
+#include "owr_uri_source_agent.h"
+#include "owr_video_renderer.h"
+#include "test_utils.h"
+
+static OwrURISourceAgent *uri_source_agent = NULL;
+static OwrMediaSource *audio_source = NULL, *video_source = NULL;
+static OwrMediaRenderer *audio_renderer = NULL, *video_renderer = NULL;
+
+/* For reading source selection from console in manual mode*/
+#include <stdio.h>
+
+#include <string.h>
+
+
+gboolean dump_pipeline(gpointer user_data)
+{
+    g_print("Dumping pipelines\n");
+
+    (void)user_data;
+
+    if (uri_source_agent)
+        write_dot_file("test_uri-source_agent", owr_uri_source_agent_get_dot_data(uri_source_agent), FALSE);
+
+    if (audio_source)
+        write_dot_file("test_uri-audio_source", owr_media_source_get_dot_data(audio_source), FALSE);
+    if (audio_renderer)
+        write_dot_file("test_uri-audio_renderer", owr_media_renderer_get_dot_data(audio_renderer), FALSE);
+
+    if (video_source)
+        write_dot_file("test_uri-video_source", owr_media_source_get_dot_data(video_source), FALSE);
+    if (video_renderer)
+        write_dot_file("test_uri-video_renderer", owr_media_renderer_get_dot_data(video_renderer), FALSE);
+
+    return FALSE;
+}
+
+void on_new_source(gpointer *unused, OwrMediaSource *source)
+{
+    static gboolean have_video = FALSE, have_audio = FALSE;
+    gchar *name = NULL;
+    OwrMediaType media_type = OWR_MEDIA_TYPE_UNKNOWN;
+
+    (void)unused;
+    g_assert(OWR_IS_URI_SOURCE(source));
+
+    if (have_video && have_audio)
+        return;
+
+    g_object_get(source, "name", &name, "media-type", &media_type, NULL);
+
+    g_print("Got \"%s\" source!\n", name ? name : "");
+
+    if (!have_video && media_type == OWR_MEDIA_TYPE_VIDEO) {
+        OwrVideoRenderer *renderer;
+
+        have_video = TRUE;
+
+        renderer = owr_video_renderer_new(NULL);
+        g_assert(renderer);
+
+        owr_media_renderer_set_source(OWR_MEDIA_RENDERER(renderer), source);
+
+        video_renderer = OWR_MEDIA_RENDERER(renderer);
+        video_source = source;
+    }
+
+    if (!have_audio && media_type == OWR_MEDIA_TYPE_AUDIO) {
+        OwrAudioRenderer *renderer;
+
+        have_audio = TRUE;
+
+        renderer = owr_audio_renderer_new();
+        g_assert(renderer);
+
+        owr_media_renderer_set_source(OWR_MEDIA_RENDERER(renderer), source);
+        audio_renderer = OWR_MEDIA_RENDERER(renderer);
+        audio_source = source;
+    }
+
+    if (have_video && have_audio) {
+        g_print("Have audio and video streams!\n");
+        owr_uri_source_agent_play(uri_source_agent);
+        g_timeout_add(10000, dump_pipeline, NULL);
+        return;
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    owr_init(NULL);
+
+    if (argc != 2) {
+        g_print("Invalid number of arguments. Usage:\n%s <uri>\n", argv[0]);
+        return -1;
+    }
+
+    uri_source_agent = owr_uri_source_agent_new(argv[1]);
+    g_signal_connect(uri_source_agent, "on-new-source", G_CALLBACK(on_new_source), NULL);
+    owr_uri_source_agent_pause(uri_source_agent);
+
+    owr_run();
+
+    return 0;
+}


### PR DESCRIPTION
Note that only the available GStreamer plugins will be used and so
format support is limited to that. On OS X, H.264 and AAC should work at
least.

Audio is a bit broken, but video seems to work OK.