### PR TITLE
Make SDP such that h264 is negotiated with Firefox.

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -54,7 +54,7 @@
         "video": [
             { "encodingName": "H264", "type": 103, "clockRate": 90000,
                 "ccmfir": true, "nackpli": true, "ericscream": true, /* "nack": true, */
-                "parameters": { "levelAsymmetryAllowed": 1, "packetizationMode": 1 } },
+                "parameters": { "profileLevelId": "42e01f", "levelAsymmetryAllowed": 1, "packetizationMode": 1 } },
 /* FIXME: Enable when Chrome can handle an offer with RTX for H264
             { "encodingName": "RTX", "type": 123, "clockRate": 90000,
                 "parameters": { "apt": 103, "rtxTime": 200 } },*/


### PR DESCRIPTION
However, I don't think it should be merged since it seems quite unstable, it seems owr often stops decoding after a short while (leaving a frozen video). Output in console (where openwebrtc-daemon is run):
```
(<unknown>:50476): libnice-WARNING **: Could not find component 2 in stream 1

** (<unknown>:50476): WARNING **: (owr_transport_agent.c:2414):on_new_remote_candidate: runtime check failed: (cands_added > 0)

(<unknown>:50476): libnice-WARNING **: Could not find component 2 in stream 1

** (<unknown>:50476): WARNING **: (owr_transport_agent.c:2414):on_new_remote_candidate: runtime check failed: (cands_added > 0)

(<unknown>:50476): libnice-WARNING **: Could not find component 2 in stream 1

** (<unknown>:50476): WARNING **: (owr_transport_agent.c:2414):on_new_remote_candidate: runtime check failed: (cands_added > 0)

(<unknown>:50476): GStreamer-CRITICAL **: gst_object_unref: assertion '((GObject *) object)->ref_count > 0' failed

(<unknown>:50476): GStreamer-CRITICAL **: gst_object_unref: assertion '((GObject *) object)->ref_count > 0' failed

(<unknown>:50476): GStreamer-CRITICAL **: gst_object_unref: assertion '((GObject *) object)->ref_count > 0' failed
```