### PR TITLE
crypto utils: Various fixes

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -527,8 +527,11 @@
                     "ssrcs": [ randomNumber(32) ],
                     "cname": cname,
                     "ice": { "ufrag": randomString(4), "password": randomString(22) },
-                    "dtls": { "setup": "actpass", "fingerprintHashFunction": "sha-256",
-                        "fingerprint": dtlsInfo.fingerprint.toUpperCase() }
+                    "dtls": {
+                        "setup": "actpass",
+                        "fingerprintHashFunction": dtlsInfo.fingerprintHashFunction,
+                        "fingerprint": dtlsInfo.fingerprint.toUpperCase()
+                    }
                 });
             });
 
@@ -539,8 +542,11 @@
                         "type": kind,
                         "payloads": JSON.parse(JSON.stringify(defaultPayloads[kind])),
                         "rtcp": { "mux": true },
-                        "dtls": { "setup": "actpass", "fingerprintHashFunction": "sha-256",
-                            "fingerprint": dtlsInfo.fingerprint.toUpperCase() },
+                        "dtls": {
+                            "setup": "actpass",
+                            "fingerprintHashFunction": dtlsInfo.fingerprintHashFunction,
+                            "fingerprint": dtlsInfo.fingerprint.toUpperCase()
+                        },
                         "mode": "recvonly"
                     });
                 }
@@ -553,8 +559,11 @@
                     "protocol": "DTLS/SCTP",
                     "fmt": 5000,
                     "ice": { "ufrag": randomString(4), "password": randomString(22) },
-                    "dtls": { "setup": "actpass", "fingerprintHashFunction": "sha-256",
-                        "fingerprint": dtlsInfo.fingerprint.toUpperCase() },
+                    "dtls": {
+                        "setup": "actpass",
+                        "fingerprintHashFunction": dtlsInfo.fingerprintHashFunction,
+                        "fingerprint": dtlsInfo.fingerprint.toUpperCase()
+                    },
                     "sctp": {
                         "port": 5000,
                         "app": "webrtc-datachannel",
@@ -622,8 +631,11 @@
                     lmdesc = {
                         "type": rmdesc.type,
                         "ice": { "ufrag": randomString(4), "password": randomString(22) },
-                        "dtls": { "setup": rmdesc.dtls.setup == "active" ? "passive" : "active",
-                            "fingerprintHashFunction": "sha-256", "fingerprint": dtlsInfo.fingerprint.toUpperCase() }
+                        "dtls": {
+                            "setup": rmdesc.dtls.setup == "active" ? "passive" : "active",
+                            "fingerprintHashFunction": dtlsInfo.fingerprintHashFunction,
+                            "fingerprint": dtlsInfo.fingerprint.toUpperCase()
+                        }
                     };
                     localSessionInfoSnapshot.mediaDescriptions.push(lmdesc);
                 }

--- a/bridge/worker/bridgeserver.js
+++ b/bridge/worker/bridgeserver.js
@@ -121,8 +121,8 @@ server.onaccept = function (event) {
 
     rpcScope.createKeys = function (client) {
         var localcertificate, localprivatekey, localfingerprint;
-        owr.crypto_create_crypto_data(function (privatekey, certificate, fingerprint) {
-            if ((privatekey && certificate && fingerprint)) {
+        owr.crypto_create_crypto_data(function (privatekey, certificate, fingerprint, fingerprintHashFunction) {
+            if ((privatekey && certificate && fingerprint && fingerprintHashFunction)) {
                 if (fingerprint == "Failure") {
                     console.log("generation of crypto data has failed");
                     client.dtlsInfoGenerationDone();
@@ -131,7 +131,8 @@ server.onaccept = function (event) {
                     client.dtlsInfoGenerationDone({
                         "certificate": certificate,
                         "privatekey": privatekey,
-                        "fingerprint": fingerprint
+                        "fingerprint": fingerprint,
+                        "fingerprintHashFunction": fingerprintHashFunction
                     });
                 }
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,7 +22,8 @@ bin_PROGRAMS = \
     test-init \
     test-bus \
     test-uri \
-    test-client
+    test-client \
+    test-crypto-utils
 
 if OWR_GST
 AM_CPPFLAGS += \
@@ -141,6 +142,16 @@ test_uri_CFLAGS = \
 test_uri_LDADD = \
     $(JSON_GLIB_LIBS) \
     $(LIBSOUP_LIBS) \
+    $(GLIB_LIBS) \
+    $(top_builddir)/owr/libopenwebrtc.la
+
+test_crypto_utils_SOURCES = test_crypto_utils.c
+
+test_crypto_utils_CFLAGS = \
+    -I$(top_srcdir)/transport \
+    -I$(top_srcdir)/owr
+
+test_crypto_utils_LDADD = \
     $(GLIB_LIBS) \
     $(top_builddir)/owr/libopenwebrtc.la
 

--- a/tests/list_devices.c
+++ b/tests/list_devices.c
@@ -32,16 +32,7 @@
 #include "owr.h"
 #include "owr_local.h"
 #include "owr_media_source.h"
-#include "owr_crypto_utils.h"
 
-static void got_crypto_data(gchar *privatekey, gchar *certificate, gchar *fingerprint)
-{
-    g_print("got got_crypto_data \n");
-    g_print("privatekey %s \n", privatekey);
-    g_print("certificate %s \n", certificate);
-    g_print("fingerprint %s \n", fingerprint);
-
-}
 static void got_sources(GList *sources, gpointer user_data)
 {
     OwrMediaSource *source = NULL;
@@ -70,7 +61,6 @@ int main() {
     owr_init(NULL);
 
     owr_get_capture_sources(OWR_MEDIA_TYPE_AUDIO|OWR_MEDIA_TYPE_VIDEO, got_sources, NULL);
-    owr_crypto_create_crypto_data(got_crypto_data);
     owr_run();
 
     return 0;

--- a/tests/test_crypto_utils.c
+++ b/tests/test_crypto_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ericsson AB. All rights reserved.
+ * Copyright (c) 2014-2015, Ericsson AB. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -23,33 +23,26 @@
  * OF SUCH DAMAGE.
  */
 
-#ifndef __OWR_CRYPTO_UTILS_H__
-#define __OWR_CRYPTO_UTILS_H__
+#include "owr.h"
+#include "owr_crypto_utils.h"
 
-#include "owr_types.h"
+static void got_crypto_data(gchar *privatekey, gchar *certificate, gchar *fingerprint,
+    gchar *fingerprint_function, gpointer data)
+{
+    g_print("got got_crypto_data \n");
+    g_print("privatekey %s \n", privatekey);
+    g_print("certificate %s \n", certificate);
+    g_print("fingerprint %s \n", fingerprint);
+    g_print("fingerprint_function %s \n", fingerprint_function);
 
-#include <glib.h>
+    owr_quit();
+}
 
-#include <openssl/ssl.h>
-#include <openssl/evp.h>
-#include <openssl/rsa.h>
+int main() {
+    owr_init(NULL);
 
-#ifndef __GTK_DOC_IGNORE__
+    owr_crypto_create_crypto_data(got_crypto_data, NULL);
+    owr_run();
 
-G_BEGIN_DECLS
-
-typedef void (*OwrCryptoDataCallback) (gchar *privatekey, gchar *certificate, gchar *fingerprint,
-    gchar *fingerprint_function, gpointer data);
-
-void owr_crypto_create_crypto_data(OwrCryptoDataCallback callback, gpointer data);
-/*< private >*/
-
-gpointer _create_crypto_worker_run(gpointer data);
-
-gboolean _create_crypto_worker_report(gpointer data);
-
-G_END_DECLS
-
-#endif /* __GTK_DOC_IGNORE__ */
-
-#endif /* __OWR_CRYPTO_UTILS_H__ */
+    return 0;
+}


### PR DESCRIPTION
* Add user data param to owr_crypto_create_crypto_data()
* Move test out of list_devices.c and into a dedicated test (test_crypto_utils.c)
* Add information on which fingerprint hash function is used to the callback
* Use returned fingerprint hash function instead of hardcoded "sha-256"

User data param is needed in the WebKit integration.
The existing test has a race between the sources callback and the crypto data callback and it's the first one that exits the test.