### PR TITLE
Related to the issue in openwebrtc-ios-sdk #27 

### DIFF
--- a/local/owr_media_renderer.c
+++ b/local/owr_media_renderer.c
@@ -308,6 +308,25 @@ static void on_caps(GstElement *sink, GParamSpec *pspec, OwrMediaRenderer *media
     }
 }
 
+void owr_media_renderer_set_state(OwrMediaRenderer *_renderer,MediaRenderState state)
+{
+    OwrMediaRenderer* renderer;
+    OwrMediaRendererPrivate *priv;
+
+    renderer = OWR_MEDIA_RENDERER(_renderer);
+    priv = renderer->priv;
+
+    switch(state){
+	case OWR_MEIDA_RENDER_STOP:{
+	    gst_element_set_state(priv->pipeline, GST_STATE_PAUSED);
+	}break;
+	case OWR_MEIDA_RENDER_PLAY:{
+	    gst_element_set_state(priv->pipeline, GST_STATE_PLAYING);
+	}break;
+	default:{}
+    }
+}
+
 static void maybe_start_renderer(OwrMediaRenderer *renderer)
 {
     OwrMediaRendererPrivate *priv;

--- a/local/owr_media_renderer.h
+++ b/local/owr_media_renderer.h
@@ -65,10 +65,18 @@ struct _OwrMediaRendererClass {
     void *(*get_sink)(OwrMediaRenderer *renderer);
 };
 
+typedef enum {
+  OWR_MEIDA_RENDER_STOP       = 0,
+  OWR_MEIDA_RENDER_PLAY       = 1
+} MediaRenderState;
+
+
 GType owr_media_renderer_get_type(void) G_GNUC_CONST;
 
 void owr_media_renderer_set_source(OwrMediaRenderer *renderer, OwrMediaSource *source);
 gchar * owr_media_renderer_get_dot_data(OwrMediaRenderer *renderer);
+
+void owr_media_renderer_set_state(OwrMediaRenderer *_renderer,MediaRenderState state);
 
 G_END_DECLS
 


### PR DESCRIPTION
added this api to call GStream API let it stop render when the app
enter background, otherwise it will going crash by GStream lib draw_cb
& run_message_sync.
https://github.com/EricssonResearch/openwebrtc-ios-sdk/issues/27
