### PR TITLE
Enable transport agent and renderer to optionally support OpenGL

### DIFF
--- a/transport/owr_payload.c
+++ b/transport/owr_payload.c
@@ -681,6 +681,7 @@ GstCaps * _owr_payload_create_raw_caps(OwrPayload *payload)
                 NULL);
         }
         caps = gst_caps_new_empty_simple("video/x-raw");
+        gst_caps_set_features(caps, 0, gst_caps_features_new_any());
         gst_caps_set_simple(caps, "width", G_TYPE_INT, width > 0 ? width : LIMITED_WIDTH, NULL);
         gst_caps_set_simple(caps, "height", G_TYPE_INT, height > 0 ? height : LIMITED_HEIGHT, NULL);
 

--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -2260,7 +2260,11 @@ static void handle_new_send_payload(OwrTransportAgent *transport_agent, OwrMedia
     g_warn_if_fail(sync_ok);
 
     if (media_type == OWR_MEDIA_TYPE_VIDEO) {
-        GstElement *flip, *queue = NULL, *encoder_capsfilter;
+        GstElement *gldownload, *flip, *queue = NULL, *encoder_capsfilter;
+
+        name = g_strdup_printf("send-input-video-gldownload-%u", stream_id);
+        gldownload = gst_element_factory_make("gldownload", name);
+        g_free(name);
 
         name = g_strdup_printf("send-input-video-flip-%u", stream_id);
         flip = gst_element_factory_make("videoflip", name);
@@ -2293,12 +2297,12 @@ static void handle_new_send_payload(OwrTransportAgent *transport_agent, OwrMedia
         g_object_set(encoder_capsfilter, "caps", caps, NULL);
         gst_caps_unref(caps);
 
-        gst_bin_add_many(GST_BIN(send_input_bin), flip, queue, encoder, encoder_capsfilter, payloader, NULL);
+        gst_bin_add_many(GST_BIN(send_input_bin), gldownload, flip, queue, encoder, encoder_capsfilter, payloader, NULL);
         if (parser) {
             gst_bin_add(GST_BIN(send_input_bin), parser);
-            link_ok &= gst_element_link_many(flip, queue, encoder, parser, encoder_capsfilter, payloader, NULL);
+            link_ok &= gst_element_link_many(gldownload, flip, queue, encoder, parser, encoder_capsfilter, payloader, NULL);
         } else
-            link_ok &= gst_element_link_many(flip, queue, encoder, encoder_capsfilter, payloader, NULL);
+            link_ok &= gst_element_link_many(gldownload, flip, queue, encoder, encoder_capsfilter, payloader, NULL);
 
         link_ok &= gst_element_link_many(payloader, rtp_capsfilter, NULL);
 
@@ -2312,9 +2316,10 @@ static void handle_new_send_payload(OwrTransportAgent *transport_agent, OwrMedia
         sync_ok &= gst_element_sync_state_with_parent(encoder);
         sync_ok &= gst_element_sync_state_with_parent(queue);
         sync_ok &= gst_element_sync_state_with_parent(flip);
+        sync_ok &= gst_element_sync_state_with_parent(gldownload);
 
         name = g_strdup_printf("video_sink_%u_%u", OWR_CODEC_TYPE_NONE, stream_id);
-        sink_pad = gst_element_get_static_pad(flip, "sink");
+        sink_pad = gst_element_get_static_pad(gldownload, "sink");
         add_pads_to_bin_and_transport_bin(sink_pad, send_input_bin,
             transport_agent->priv->transport_bin, name);
         gst_object_unref(sink_pad);


### PR DESCRIPTION
The following patches enable the transport agent and renderer to optionally work with GLMemory. This is part of my work to make OWR offload most video processing to OpenGL in order to improve performance.

This PR doesn't yet include the changes to enable OpenGL at the source, since doing that currently works with H264 but breaks VP8 encoding. I'm submitting this now since these commits are independent from the source changes and don't break anything, so people can start reviewing them.