### PR TITLE
Enable OpenGL in media sources

### DIFF
--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -352,9 +352,8 @@ fix_video_caps_framerate(GstCapsFeatures *f, GstStructure *s, gpointer user_data
 {
     GstCaps *ret = GST_CAPS(user_data);
     gint fps_n, fps_d;
-    OWR_UNUSED(f);
 
-    gst_caps_append_structure(ret, gst_structure_copy(s));
+    gst_caps_append_structure_full(ret, gst_structure_copy(s), gst_caps_features_copy(f));
 
     /* Don't mess with non-raw structures */
     if (!gst_structure_has_name(s, "video/x-raw"))
@@ -364,7 +363,7 @@ fix_video_caps_framerate(GstCapsFeatures *f, GstStructure *s, gpointer user_data
     if (gst_structure_get_fraction(s, "framerate", &fps_n, &fps_d)) {
         GstStructure *tmp = gst_structure_copy(s);
         gst_structure_remove_field(tmp, "framerate");
-        gst_caps_append_structure(ret, tmp);
+        gst_caps_append_structure_full(ret, tmp, gst_caps_features_copy(f));
     }
 
 done:

--- a/transport/owr_payload.c
+++ b/transport/owr_payload.c
@@ -681,7 +681,10 @@ GstCaps * _owr_payload_create_raw_caps(OwrPayload *payload)
                 NULL);
         }
         caps = gst_caps_new_empty_simple("video/x-raw");
-        gst_caps_set_features(caps, 0, gst_caps_features_new_any());
+#ifdef __APPLE__
+        if (priv->codec_type == OWR_CODEC_TYPE_H264)
+          gst_caps_set_features(caps, 0, gst_caps_features_new_any());
+#endif
         gst_caps_set_simple(caps, "width", G_TYPE_INT, width > 0 ? width : LIMITED_WIDTH, NULL);
         gst_caps_set_simple(caps, "height", G_TYPE_INT, height > 0 ? height : LIMITED_HEIGHT, NULL);
 


### PR DESCRIPTION
This is the change to actually enable OpenGL at the source. The commit log says it all:

    media source: optional OpenGL support

    Enable OpenGL for peers that support it. This means that OWR will now use
    GLMemory between source -> renderer and source -> apple h264 encoders.

    The implication is that in the above cases color conversion and scaling are done
    via GL shaders. Also on Mac and iOS, memory is shared directly between the
    camera and the renderer/encoders saving expensive GPU => sysmem memory copies.