### PR TITLE
Fix infinite loop on img.onerror

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -1710,11 +1710,11 @@
                         retryTime += 300;
                         if (shouldAbort())
                             return;
-                    }
 
-                    setTimeout(function () {
-                        img.src = imgUrl ? imgUrl + (++count % roll) : "";
-                    }, retryTime || 100);
+                        setTimeout(function () {
+                            img.src = imgUrl ? imgUrl + (++count % roll) : "";
+                        }, retryTime || 100);
+                    }
                 };
 
                 var muted = video.muted;


### PR DESCRIPTION
When onerror is called while unload was never called, we end up on an infinite loop updating an erroneous image.