### PR TITLE
Changed SDP parsing to remove also RTX payloads from answer when corr…

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -866,7 +866,10 @@
                         || payload.parameters.packetizationMode == dp.parameters.packetizationMode);
 
                 });
-                mdesc.payloads = filteredPayloads;
+                mdesc.payloads = filteredPayloads.filter(function (payload) {
+                    return !payload.parameters || !payload.parameters.apt ||
+                    indexOfByProperty(filteredPayloads, "type", payload.parameters.apt) != -1;
+                });
 
                 var trackIndex = indexOfByProperty(allTracks, "kind", mdesc.type);
                 if (trackIndex != -1) {


### PR DESCRIPTION
…esponding codec has been removed. Needed to interop with Chrome 50.

Fixing the problem reported in #594. Thanks to @y-element for reporting and providing the fix.
Close #594 