### PR TITLE
Modified to allow spaces between parameters on fmtp lines.

### DIFF
--- a/bridge/client/sdp.js
+++ b/bridge/client/sdp.js
@@ -41,7 +41,7 @@ if (typeof(SDP) == "undefined")
         "mblock": "^m=(audio|video|application) ([\\d]+) ([A-Z/]+)([\\d ]*)$\\r?\\n",
         "mode": "^a=(sendrecv|sendonly|recvonly|inactive).*$",
         "rtpmap": "^a=rtpmap:${type} ([\\w\\-]+)/([\\d]+)/?([\\d]+)?.*$",
-        "fmtp": "^a=fmtp:${type} ([\\w\\-=;]+).*$",
+        "fmtp": "^a=fmtp:${type} ([\\w\\-=; ]+).*$",
         "param": "([\\w\\-]+)=([\\w\\-]+);?",
         "nack": "^a=rtcp-fb:${type} nack$",
         "nackpli": "^a=rtcp-fb:${type} nack pli$",

--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -55,9 +55,8 @@
             { "encodingName": "H264", "type": 103, "clockRate": 90000,
                 "ccmfir": true, "nackpli": true, "ericscream": true, /* "nack": true, */
                 "parameters": { "levelAsymmetryAllowed": 1, "packetizationMode": 1 } },
-/* FIXME: Enable when Chrome can handle an offer with RTX for H264
             { "encodingName": "RTX", "type": 123, "clockRate": 90000,
-                "parameters": { "apt": 103, "rtxTime": 200 } },*/
+                "parameters": { "apt": 103, "rtxTime": 200 } },
             { "encodingName": "VP8", "type": 100, "clockRate": 90000,
                 "ccmfir": true, "nackpli": true, "nack": true, "ericscream": true },
             { "encodingName": "RTX", "type": 120, "clockRate": 90000,


### PR DESCRIPTION
Chrome's first implementation of h264 has an SDP with fmtp lines like
```
a=fmtp:107 level-asymmetry-allowed=1; packetization-mode=1; profile-level-id=42e01f
```
(note spaces between parameters). While unusual this does not seem illegal, and this patch is to enable openwebrtc to properly parse such fmtp lines.