### PR TITLE
Removing RTX for h264 from SDP as Chrome does not work correctly with…

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -55,8 +55,10 @@
             { "encodingName": "H264", "type": 103, "clockRate": 90000,
                 "ccmfir": true, "nackpli": true, "ericscream": true, /* "nack": true, */
                 "parameters": { "levelAsymmetryAllowed": 1, "packetizationMode": 1 } },
+        /* It turns our Chrome still does not handle RTX for h264 correctly, so making
+        it not be negotiated
             { "encodingName": "RTX", "type": 123, "clockRate": 90000,
-                "parameters": { "apt": 103, "rtxTime": 200 } },
+                "parameters": { "apt": 103, "rtxTime": 200 } },  */
             { "encodingName": "VP8", "type": 100, "clockRate": 90000,
                 "ccmfir": true, "nackpli": true, "nack": true, "ericscream": true },
             { "encodingName": "RTX", "type": 120, "clockRate": 90000,


### PR DESCRIPTION
… it. Removes problems with freezing remote video (sent from Chrome Canary using h264) on owr.