### PR TITLE
Updated to allow RTX to be negotiated for h264 since this seems fixed…

### DIFF
--- a/bridge/client/webrtc.js
+++ b/bridge/client/webrtc.js
@@ -53,12 +53,10 @@
         ],
         "video": [
             { "encodingName": "H264", "type": 103, "clockRate": 90000,
-                "ccmfir": true, "nackpli": true, "ericscream": true, /* "nack": true, */
+                "ccmfir": true, "nackpli": true, "ericscream": true, "nack": true,
                 "parameters": { "levelAsymmetryAllowed": 1, "packetizationMode": 1 } },
-        /* It turns our Chrome still does not handle RTX for h264 correctly, so making
-        it not be negotiated
             { "encodingName": "RTX", "type": 123, "clockRate": 90000,
-                "parameters": { "apt": 103, "rtxTime": 200 } },  */
+                "parameters": { "apt": 103, "rtxTime": 200 } },
             { "encodingName": "VP8", "type": 100, "clockRate": 90000,
                 "ccmfir": true, "nackpli": true, "nack": true, "ericscream": true },
             { "encodingName": "RTX", "type": 120, "clockRate": 90000,


### PR DESCRIPTION
… in Chrome now. See https://bugs.chromium.org/p/webrtc/issues/detail?id=5810&can=2&start=0&num=100&q=&colspec=ID%20Pri%20Mstone%20ReleaseBlock%20Component%20Status%20Owner%20Summary&groupby=&sort= for some more info.