### PR TITLE
owr_video_renderer: GL context request support

### DIFF
--- a/local/owr_media_renderer.c
+++ b/local/owr_media_renderer.c
@@ -480,3 +480,11 @@ gchar * owr_media_renderer_get_dot_data(OwrMediaRenderer *renderer)
     return g_strdup("");
 #endif
 }
+
+GstPipeline * _owr_media_renderer_get_pipeline(OwrMediaRenderer *renderer)
+{
+    g_return_val_if_fail(OWR_IS_MEDIA_RENDERER(renderer), NULL);
+    g_return_val_if_fail(renderer->priv->pipeline, NULL);
+
+    return gst_object_ref(GST_PIPELINE(renderer->priv->pipeline));
+}

--- a/local/owr_media_renderer_private.h
+++ b/local/owr_media_renderer_private.h
@@ -33,10 +33,12 @@
 #define __OWR_MEDIA_RENDERER_PRIVATE_H__
 
 #include "owr_media_renderer.h"
+#include <gst/gst.h>
 
 G_BEGIN_DECLS
 
 void _owr_media_renderer_set_sink(OwrMediaRenderer *renderer, gpointer sink);
+GstPipeline * _owr_media_renderer_get_pipeline(OwrMediaRenderer *renderer);
 
 G_END_DECLS
 

--- a/local/owr_video_renderer.h
+++ b/local/owr_video_renderer.h
@@ -62,6 +62,10 @@ GType owr_video_renderer_get_type(void) G_GNUC_CONST;
 
 OwrVideoRenderer *owr_video_renderer_new(const gchar *tag);
 
+typedef struct _GstContext GstContext;
+typedef GstContext* (* OwrVideoRendererRequestContextCallback) (const gchar* context_type, gpointer user_data);
+void owr_video_renderer_set_request_context_callback(OwrVideoRenderer *renderer, OwrVideoRendererRequestContextCallback callback, gpointer user_data, GDestroyNotify destroy_data);
+
 G_END_DECLS
 
 #endif /* __OWR_VIDEO_RENDERER_H__ */


### PR DESCRIPTION
When the application using the renderer has a GL video sink using a
shared GL context and display, the NEED_CONTEXT synchronous message
emitted on the renderer pipeline bus has to be relayed to the
application.

Using a GClosure, OpenWebRTC can request the needed context from the
application side, which has to register a GCallback that returns a
pointer to a GstContext structure.