### PR TITLE
Fix wrongly handled absence of candidates

### DIFF
--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -583,8 +583,8 @@ end_payload:
                     g_object_unref(remote_candidate);
                 json_reader_end_element(reader);
             }
-            json_reader_end_member(reader); /* candidates */
         }
+        json_reader_end_member(reader); /* candidates */
         json_reader_end_member(reader); /* ice */
 
         json_reader_end_element(reader);


### PR DESCRIPTION
Accoding to json-glib documentation: https://developer.gnome.org/json-glib/stable/JsonReader.html

"If reader is not currently on an object, or if the member_name is not defined in the object, the JsonReader will be put in an error state until json_reader_end_member() is called. This means that if used conditionally, json_reader_end_member() must be called on both code paths."