### PR TITLE
Fixup the RTLD_DEFAULT patch to also work on all 32 bit devices

### DIFF
--- a/local/owr_device_list.c
+++ b/local/owr_device_list.c
@@ -513,7 +513,11 @@ static JavaVM *get_java_vm(void)
 
     while (android_runtime_libs[lib_index] && !handle) {
         dlerror();
+#if defined(__BIONIC__) && !defined(__LP64__)
+        handle = RTLD_DEFAULT;
+#else
         handle = dlopen(android_runtime_libs[lib_index], RTLD_LOCAL | RTLD_LAZY);
+#endif         
         error_string = dlerror();
 
         if (error_string)


### PR DESCRIPTION
fix android 7.0 JNI_GetCreatedJavaVMs failed #672 
refer
https://github.com/GStreamer/cerbero/commit/96bdc6498ad86b985e12163bd0f833c4e8b59803