### PR TITLE
Fix build with gcc-7

### DIFF
--- a/local/owr_local_media_source.c
+++ b/local/owr_local_media_source.c
@@ -379,6 +379,7 @@ static gboolean bus_call(GstBus *bus, GstMessage *msg, gpointer user_data)
 
     case GST_MESSAGE_WARNING:
         is_warning = TRUE;
+        /* fallthru */
 
     case GST_MESSAGE_ERROR:
         if (is_warning) {

--- a/local/owr_media_renderer.c
+++ b/local/owr_media_renderer.c
@@ -179,7 +179,7 @@ static gboolean bus_call(GstBus *bus, GstMessage *msg, gpointer user_data)
 
     case GST_MESSAGE_WARNING:
         is_warning = TRUE;
-
+        /* fallthru */
     case GST_MESSAGE_ERROR:
         if (is_warning) {
             message_type = "Warning";

--- a/local/owr_uri_source_agent.c
+++ b/local/owr_uri_source_agent.c
@@ -165,6 +165,7 @@ static gboolean bus_call(GstBus *bus, GstMessage *msg, gpointer user_data)
 
     case GST_MESSAGE_WARNING:
         is_warning = TRUE;
+        /* fallthru */
 
     case GST_MESSAGE_ERROR:
         if (is_warning) {

--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -391,7 +391,7 @@ static gboolean bus_call(GstBus *bus, GstMessage *msg, gpointer user_data)
 
     case GST_MESSAGE_WARNING:
         is_warning = TRUE;
-
+        /* fallthru */
     case GST_MESSAGE_ERROR:
         if (is_warning) {
             message_type = "Warning";


### PR DESCRIPTION
Fixes warnings about fall through in case statements

../../git/transport/owr_transport_agent.c: In function 'bus_call':
../../git/transport/owr_transport_agent.c:393:20: error: this statement may fall through [-Werror=implicit-fallthrough=]
         is_warning = TRUE;

Signed-off-by: Khem Raj <raj.khem@gmail.com>